### PR TITLE
Java5 compatibility

### DIFF
--- a/src/main/java/com/samskivert/mustache/BasicCollector.java
+++ b/src/main/java/com/samskivert/mustache/BasicCollector.java
@@ -11,7 +11,6 @@ import java.util.Map;
  */
 public class BasicCollector implements Mustache.Collector
 {
-    @Override
     public Iterator<?> toIterator (final Object value) {
         if (value instanceof Iterable<?>) {
             return ((Iterable<?>)value).iterator();
@@ -22,7 +21,6 @@ public class BasicCollector implements Mustache.Collector
         return null;
     }
 
-    @Override
     public Mustache.VariableFetcher createFetcher (Object ctx, String name)
     {
         // support both .name and this.name to fetch members
@@ -38,13 +36,13 @@ public class BasicCollector implements Mustache.Collector
     }
 
     protected static final Mustache.VariableFetcher MAP_FETCHER = new Mustache.VariableFetcher() {
-        @Override public Object get (Object ctx, String name) throws Exception {
+        public Object get (Object ctx, String name) throws Exception {
             return ((Map<?,?>)ctx).get(name);
         }
     };
 
     protected static final Mustache.VariableFetcher THIS_FETCHER = new Mustache.VariableFetcher() {
-        @Override public Object get (Object ctx, String name) throws Exception {
+        public Object get (Object ctx, String name) throws Exception {
             return ctx;
         }
     };

--- a/src/main/java/com/samskivert/mustache/DefaultCollector.java
+++ b/src/main/java/com/samskivert/mustache/DefaultCollector.java
@@ -43,7 +43,7 @@ public class DefaultCollector extends BasicCollector
         final Method m = getMethod(cclass, name);
         if (m != null) {
             return new Mustache.VariableFetcher() {
-                @Override public Object get (Object ctx, String name) throws Exception {
+                public Object get (Object ctx, String name) throws Exception {
                     return m.invoke(ctx);
                 }
             };
@@ -52,7 +52,7 @@ public class DefaultCollector extends BasicCollector
         final Field f = getField(cclass, name);
         if (f != null) {
             return new Mustache.VariableFetcher() {
-                @Override public Object get (Object ctx, String name) throws Exception {
+                public Object get (Object ctx, String name) throws Exception {
                     return f.get(ctx);
                 }
             };


### PR DESCRIPTION
Hi,

I've removed @Override annotation from implementation methods (which don't override an existing implementation) to make the code Java5 compatible.

The issue causing this is a whole different story but the problem is that javac of Java6 doesn't warn you about this even when you compile the code with -source/-target 1.5 only ecj (Eclipse compiler for Java) can catch and report this incompatibility,

Regards,
Serkan
