### PR TITLE
Add OSGi headers in manifest file using maven-bundle-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>com.samskivert</groupId>
   <artifactId>jmustache</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <version>1.6-SNAPSHOT</version>
+
   <name>jmustache</name>
   <description>A Java implementation of the Mustache templating language.</description>
   <url>http://github.com/samskivert/jmustache</url>
@@ -82,6 +85,19 @@
           <excludes>
             <exclude>com/samskivert/gwt/**</exclude>
           </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_removeheaders>
+              Bnd*,Created-By,Include-Resource,Private-Package,Tool
+            </_removeheaders>
+          </instructions>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
I've tested using this as a bundle in Eclipse, used by a plug-in.

Yes, adding a build-time dependency for just a couple of lines in the MANIFEST.MF is a little over the top. However, I assume you don't need OSGi support and won't be testing it, so using maven-bundle-plugin seems like the most robust way to add OSGi headers in this case.
