### PR TITLE
Use entity number when escaping apostrophes for IE compatibility.

### DIFF
--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -640,7 +640,7 @@ public class Mustache
      * need to be applied in order so amps are not double escaped.) */
     protected static final String[][] ATTR_ESCAPES = {
         { "&", "&amp;" },
-        { "'", "&apos;" },
+        { "'", "&#39;" },
         { "\"", "&quot;" },
         { "<", "&lt;" },
         { ">", "&gt;" },


### PR DESCRIPTION
The &amp;apos; entity is rendered verbatim in Internet Explorer, rather than as an apostrophe. Prior to HTML5, 'apos' is an XML entity, but not an [HTML entity](http://www.w3.org/TR/html401/sgml/entities.html).

Using the entity number (#39) is valid in both HTML and XML.

This change escapes single quotes using &amp;#39; rather than &amp;apos;.

See also:
- [The Curse of &amp;apos;](http://fishbowl.pastiche.org/2003/07/01/the_curse_of_apos/)
- [Internet explorer - how do you escape single quotes](http://stackoverflow.com/questions/1213507/internet-explorer-how-do-you-escape-single-quotes)
