### PR TITLE
Add Bundle-ActivationPolicy to OSGi manifest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
             <_removeheaders>
               Bnd*,Created-By,Include-Resource,Private-Package,Tool
             </_removeheaders>


### PR DESCRIPTION
Set the Bundle-ActivationPolicy to 'lazy'. According to the OSGi wiki:

  "This can improve performance in a system with many bundles, where
  instead of starting them they may be placed into a lazy state, and
  only activated when they are actually used."
  -- http://wiki.osgi.org/wiki/Bundle-ActivationPolicy

'Lazy' is fine for jmustache, because it has no bundle activator,
and does not provide any OSGi services that need to be registered.

(Again, tested as an Eclipse bundle. I used the 'ss' command in the Equinox OSGi console to check that the bundle is not resolved until it is actually used.)
