### PR TITLE
Add option to treat empty string as falsy values

### DIFF
--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -138,6 +138,12 @@ public class MustacheTest
         });
     }
 
+    @Test public void testSectionWithEmptyString () {
+        test(Mustache.compiler().emptyStringIsFalse(true), "", "{{#foo}}test{{/foo}}", new Object() {
+            String foo = "";
+        });
+    }
+
     @Test public void testMissingSection () {
         test("", "{{#foo}}{{bar}}{{/foo}}", new Object() {
             // no foo


### PR DESCRIPTION
In javascript implementation of mustache, empty string are treated as falsy values. It means that something like : 
`{{#emptyString}}foo{{/emptyString}}`
with `emptyString === ''` is treated.
In JMustache, only null values are treated as falsy values. I added an option (`emptyStringIsFalse`, default is false to not change current behavior) to treat empty string as a false value.
