### PR TITLE
Show the name of variable that is null or missing

### DIFF
--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -38,7 +38,10 @@ public class Mustache
 
         /** A value to use when a variable resolves to null. If this value is null (which is the
          * default null value), an exception will be thrown. If {@link #missingIsNull} is also
-         * true, this value will be used when a variable cannot be resolved. */
+         * true, this value will be used when a variable cannot be resolved.
+         * If the nullValue contains a substring "{{name}}", then this substring
+         * will be replaced by name of the variable. For example, if nullValue="?{{name}}?"
+         * and the missing variable is "foo", then string "?foo?" will be used. */
         public final String nullValue;
 
         /** If this value is true, missing variables will be treated like variables that return

--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -170,7 +170,16 @@ public class Template
         // getValue will raise MustacheException if a variable cannot be resolved and missingIsNull
         // is not configured; so we're safe to assume that any null that makes it up to this point
         // can be converted to nullValue
-        return (value == null) ? _compiler.nullValue : value;
+        return (value == null) ? substituteNullValue(name) : value;
+    }
+
+    private String substituteNullValue(String name) {
+        String SUBST = "\\{\\{name\\}\\}"; // escaping needed for regex
+        String result = _compiler.nullValue;
+        if (result != null) {
+            result = result.replaceAll(SUBST, name);
+        }
+        return result;
     }
 
     protected Object getValueIn (Object data, String name, int line)

--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -444,6 +444,21 @@ public class MustacheTest
              "foobar", "{{missing}}{{notmissing}}", context("notmissing", "bar"));
     }
 
+    @Test public void testMissingValueWithDefaultSubstitution () {
+        test(Mustache.compiler().defaultValue("?{{name}}?"),
+             "?missing?bar", "{{missing}}{{notmissing}}", context("notmissing", "bar"));
+    }
+
+    @Test public void testMissingValueWithDefaultSubstitution2 () {
+        test(Mustache.compiler().defaultValue("{{{{name}}}}"),
+             "{{missing}}bar", "{{missing}}{{notmissing}}", context("notmissing", "bar"));
+    }
+
+    @Test public void testMissingValueWithDefaultSubstitution3 () {
+        test(Mustache.compiler().defaultValue("{{?{{name}}?}}"),
+             "{{?missing?}}bar", "{{missing}}{{notmissing}}", context("notmissing", "bar"));
+    }
+
     @Test public void testNullValueGetsDefault () {
         test(Mustache.compiler().defaultValue("foo"),
              "foobar", "{{nullvar}}{{nonnullvar}}", new Object() {


### PR DESCRIPTION
If Compiler.nullValue contains a substring "{{name}}", then this substring
will be replaced with the name of variable.
For example, if nullValue="?{{name}}?" and variable is resolved to null,
then string "?foo?" will be used in the output.
