### PR TITLE
Added method to get all keys (variables, sections) found in the template

### DIFF
--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -8,9 +8,10 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents a compiled template. Templates are executed with a <em>context</em> to generate
@@ -83,6 +84,21 @@ public class Template
     {
         Context pctx = new Context(parentContext, null, 0, false, false);
         executeSegs(new Context(context, pctx, 0, false, false), out);
+    }
+
+    /** Return all keys found in the template as variables or section names.
+     *  Note that keys are result of static parsing, no context evaluation was applied
+     *  (e.g. a variable will be listed even if is used in a section that is always skipped).
+     *  For the same reason, keys in lambda fragments are included here.
+     *  Partials are processed recursively (because they are included at parse time).
+     *
+     */
+    public Set<String> getKeys() {
+        Set<String> keys = new HashSet<String>();
+        for (Segment seg : _segs) {
+            seg.getKeys(keys);
+        }
+        return keys;
     }
 
     protected Template (Segment[] segs, Mustache.Compiler compiler)
@@ -276,6 +292,9 @@ public class Template
     protected static abstract class Segment
     {
         abstract void execute (Template tmpl, Context ctx, Writer out);
+
+        /** Add keys of this segment to the set. */
+        abstract protected Set<String> getKeys(Set<String> keys);
 
         protected static void write (Writer out, String data) {
             try {

--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -15,7 +15,10 @@ import java.io.Writer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -510,6 +513,18 @@ public class MustacheTest
                      else return "Who was that man?";
                  }
              }));
+    }
+
+    @Test public void testGetKeys() {
+        String template = "{{#one}}1{{/one}} {{^two}}2{{three}}{{/two}}{{four}}";
+        Set<String> keys = Mustache.compiler().compile(template).getKeys();
+        assertEquals(new HashSet<String>(Arrays.asList("one", "two", "three", "four")), keys);
+    }
+
+    @Test public void testGetKeys2() {
+        String template = "{{#one}}1{{/one}} {{^two}}2{{two_and_half}}{{#five}}{{three}}{{/five}}{{/two}} {{#one}}{{three}}{{/one}} {{four}}{{! ignore me }}";
+        Set<String> keys = Mustache.compiler().compile(template).getKeys();
+        assertEquals(new HashSet<String>(Arrays.asList("one", "two", "three", "four", "two_and_half", "five")), keys);
     }
 
     protected void test (Mustache.Compiler compiler, String expected, String template, Object ctx)


### PR DESCRIPTION
Can be used as a convenience tool to assist users  when preparing context for existing template.

We need a mechanism for validation: users are preparing context interactively, while the template was already defined. We'd like to show them what keys are still missing. 
I think that such method could be useful for others?
