### PR TITLE
Added MustacheContextException

### DIFF
--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -609,8 +609,8 @@ public class Mustache
         @Override public void execute (Template tmpl, Template.Context ctx, Writer out)  {
             Object value = tmpl.getValueOrDefault(ctx, _name, _line);
             if (value == null) {
-                throw new MustacheException(
-                    "No key, method or field with name '" + _name + "' on line " + _line);
+                throw new MustacheContextException(
+                    "No key, method or field with name '" + _name + "' on line " + _line, _name, _line);
             }
             String text = String.valueOf(value);
             write(out, _escapeHTML ? escapeHTML(text) : text);

--- a/src/main/java/com/samskivert/mustache/MustacheContextException.java
+++ b/src/main/java/com/samskivert/mustache/MustacheContextException.java
@@ -1,0 +1,32 @@
+package com.samskivert.mustache;
+
+/**
+ * An exception thrown if we encounter an unsatisfactory context error (e.g. a missing variable) while executing a template.
+ */
+public class MustacheContextException extends MustacheException {
+    private String key;
+    private int lineNo;
+
+    public MustacheContextException (String message, String key, int lineNo) {
+        super(message);
+        this.key = key;
+        this.lineNo = lineNo;
+    }
+
+    public MustacheContextException (String message, String key, int lineNo, Throwable cause) {
+        super(message, cause);
+        this.key = key;
+        this.lineNo = lineNo;
+    }
+
+    /** Get key (e.g. variable or section name) that caused the problem. */
+    public String getKey() {
+        return key;
+    }
+
+    /** Line number where the problem occurred. */
+    public int getLineNo() {
+        return lineNo;
+    }
+
+}

--- a/src/main/java/com/samskivert/mustache/MustacheException.java
+++ b/src/main/java/com/samskivert/mustache/MustacheException.java
@@ -9,11 +9,6 @@ package com.samskivert.mustache;
  */
 public class MustacheException extends RuntimeException
 {
-    public static class Parse extends MustacheException {
-        public Parse (String message) {
-            super(message);
-        }
-    }
 
     public MustacheException (String message) {
         super(message);

--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -134,9 +134,9 @@ public class Template
                 Object data = getValue(ctx, comps[0].intern(), line, missingIsNull);
                 for (int ii = 1; ii < comps.length; ii++) {
                     if (data == NO_FETCHER_FOUND) {
-                        if (!missingIsNull) throw new MustacheException(
+                        if (!missingIsNull) throw new MustacheContextException(
                             "Missing context for compound variable '" + name + "' on line " + line +
-                            ". '" + comps[ii - 1] + "' was not found.");
+                            ". '" + comps[ii - 1] + "' was not found.", name, line);
                         return null;
                     } else if (data == null) {
                         return null;
@@ -231,8 +231,8 @@ public class Template
             _fcache.put(key, fetcher);
             return value;
         } catch (Exception e) {
-            throw new MustacheException(
-                "Failure fetching variable '" + name + "' on line " + line, e);
+            throw new MustacheContextException(
+                "Failure fetching variable '" + name + "' on line " + line, name, line, e);
         }
     }
 
@@ -240,8 +240,8 @@ public class Template
     {
         if (value == NO_FETCHER_FOUND) {
             if (missingIsNull) return null;
-            throw new MustacheException(
-                "No method or field with name '" + name + "' on line " + line);
+            throw new MustacheContextException(
+                "No method or field with name '" + name + "' on line " + line, name, line);
         } else {
             return value;
         }


### PR DESCRIPTION
Solving a need to distinguish context errors from environment errors (mostly IOExceptions, wrapped into MustacheException).
  The new exception has fields for the offending key and line number. This
  is a first step towards internationalization of messages (sufficient for my immediate needs, because I could catch all MustacheContextExceptions and display a general error message with the key as a parameter).
