### PR TITLE
Fixes issue 28, comments containing '}' parsed as text

### DIFF
--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -335,10 +335,11 @@ public class Mustache
                         parseChar(NO_CHAR);
                     }
 
-                } else if (c == delims.start1 && text.length() > 0) {
+                } else if (c == delims.start1 && text.length() > 0 && text.charAt(0) != '!') {
                     // if we've already matched some tag characters and we see a new start tag
                     // character (e.g. "{{foo {" but not "{{{"), treat the already matched text as
-                    // plain text and start matching a new tag from this point
+                    // plain text and start matching a new tag from this point, unless we're in
+                    // a comment tag.
                     restoreStartTag(text, delims);
                     accum.addTextSegment(text);
                     tagStartColumn = column;

--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -169,6 +169,10 @@ public class MustacheTest
         test("foobar", "foo{{! nothing to see here}}bar", new Object());
     }
 
+    @Test public void testCommentWithFunnyChars() {
+        test("foobar", "foo{{! {baz\n }}bar", new Object());
+    }
+
     @Test(expected=UnsupportedOperationException.class)
     public void testPartialUseWhenUnconfigured () {
         test(null, "{{>foo}}", null);


### PR DESCRIPTION
Quick fix to Mustache.Parser.parseChar.

When in the TAG state, the parseChar checks for a start delimiter in the middle of the tag text.  If it finds one, it decides the tag text it'd been accumulating is actually plain text, and moves to MATCHING_START.

Fix is to check if the tag is a comment tag before taking any action, by adding:

```
text.charAt(0) != '!'
```

to the condition (comments open with '!').

Also added a test case that fails on previous commit, but passes with the fix.
