### PR TITLE
Added a note that the 1.6 JAR doesn't have Lambdas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Get It
 JMustache is available via Maven Central and can thus be easily added to your
 Maven, Ivy, etc. projects by adding a dependency on
 `com.samskivert:jmustache:1.6`. Or download the [pre-built jar
-file](http://repo1.maven.org/maven2/com/samskivert/jmustache/1.6/jmustache-1.6.jar).
+file](http://repo1.maven.org/maven2/com/samskivert/jmustache/1.6/jmustache-1.6.jar) (which does not contain Lambdas).
 
 Usage
 =====


### PR DESCRIPTION
Ran `unzip -l` on the 1.6 JAR file from the Maven repo after being unable to import `Mustache.Lambda`. I didn't see it noted anywhere that not all of the features in the README are available with the pre-built archive.
