### PR TITLE
Access Array item by index in template

### DIFF
--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -7,8 +7,12 @@ package com.samskivert.mustache;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -139,7 +143,18 @@ public class Template
                     }
                     // once we step into a composite key, we drop the ability to query our parent
                     // contexts; that would be weird and confusing
-                    data = getValueIn(data, comps[ii].intern(), line);
+                    String next = comps[ii].intern();
+                    Integer idx = toNumber(next);
+                    if (idx != null) {
+                        Object nextData = null;
+                        List<Object> c = toList(data);
+                        if (c != null && idx >= 0 && idx < c.size()) {
+                            nextData = c.get(idx);
+                        }
+                        data = nextData;
+                    } else {
+                        data = getValueIn(data, next, line);
+                    }
                 }
                 return checkForMissing(name, line, missingIsNull, data);
             }
@@ -167,6 +182,30 @@ public class Template
         // we've popped off the top of our stack of contexts; we never found a fetcher for our
         // variable, so let checkForMissing() decide what to do
         return checkForMissing(name, line, missingIsNull, NO_FETCHER_FOUND);
+    }
+
+    protected static List<Object> toList(Object obj) {
+        if (obj instanceof Collection) {
+            return new ArrayList<Object>((Collection) obj);
+        } else if (obj instanceof Iterator) {
+            Iterator<Object> it = (Iterator<Object>) obj;
+            List<Object> lst = new ArrayList<Object>();
+            while (it.hasNext()) {
+                lst.add(it.next());
+            }
+            return lst;
+        } else if (obj instanceof Object[]) {
+            return Arrays.asList((Object[]) obj);
+        }
+        return null;
+    }
+
+    protected static Integer toNumber(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 
     /**

--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -87,16 +87,50 @@ public class MustacheTest
                  "foo", Arrays.asList(context("bar", "baz"), context("bar", "bif"))));
     }
 
+    @Test public void testListIndexSection() {
+        test("baz", "{{#foo.0}}{{bar}}{{/foo.0}}", context(
+            "foo", Arrays.asList(context("bar", "baz"), context("bar", "bif"))));
+    }
+
+    @Test public void testListItemSection() {
+        test("baz", "{{foo.0.bar}}", context(
+            "foo", Arrays.asList(context("bar", "baz"), context("bar", "bif"))));
+    }
+
     @Test public void testArraySection () {
         test("bazbif", "{{#foo}}{{bar}}{{/foo}}",
              context("foo", new Object[] {
                      context("bar", "baz"), context("bar", "bif") }));
     }
 
+    @Test public void testArrayIndexSection () {
+        test("baz", "{{#foo.0}}{{bar}}{{/foo.0}}",
+            context("foo", new Object[] {
+                context("bar", "baz"), context("bar", "bif") }));
+    }
+
+    @Test public void testArrayItemSection () {
+        test("baz", "{{foo.0.bar}}",
+            context("foo", new Object[] {
+                context("bar", "baz"), context("bar", "bif") }));
+    }
+
     @Test public void testIteratorSection () {
         test("bazbif", "{{#foo}}{{bar}}{{/foo}}",
              context("foo", Arrays.asList(context("bar", "baz"),
                                           context("bar", "bif")).iterator()));
+    }
+
+    @Test public void testIteratorIndexSection () {
+        test("baz", "{{#foo.0}}{{bar}}{{/foo.0}}",
+            context("foo", Arrays.asList(context("bar", "baz"),
+                context("bar", "bif")).iterator()));
+    }
+
+    @Test public void testIteratorItemSection () {
+        test("baz", "{{foo.0.bar}}",
+            context("foo", Arrays.asList(context("bar", "baz"),
+                context("bar", "bif")).iterator()));
     }
 
     @Test public void testEmptyListSection () {


### PR DESCRIPTION
With this patch, you can access directly items by index in templates :

With a list like : 
  items = ['foo', 'bar']

you can use this template :
  {{item.0}}

it will render : 
  foo

Solving a different behavior with the javascript implementation as you can see here : https://github.com/janl/mustache.js/issues/158
