### PR TITLE
Add an Mustache capabilities to Ant, based on JMustache

### DIFF
--- a/ant-mustache.expected
+++ b/ant-mustache.expected
@@ -1,0 +1,26 @@
+Hello,
+
+1. replace value:
+v = V
+k.v = K.V
+
+2. test
+mytrue? = true
+mytrue? is valid (not false nor empty list), showing this!
+
+myfalse? = false
+myfalse? is NOT valid (false or empty list), showing that!
+
+doesnotexist is NOT valid (false or empty list), showing that!
+
+3. list
+l is empty or not set
+
+mylist = [{prop2=value-1-2, prop1=value-1-1, __id__=01}, {prop2=value-2-2, prop1=value-2-1, __id__=02}]
+01.prop1 = value-1-1
+01.prop2 = value-1-2
+02.prop1 = value-2-1
+02.prop2 = value-2-2
+
+4. direct access:
+l[02].b = L[02].B

--- a/ant-mustache.properties
+++ b/ant-mustache.properties
@@ -1,0 +1,17 @@
+v = V
+k.v = K.V
+
+mytrue? = true
+myfalse? = false
+
+l[01].a = L[01].A
+l[01].b = L[01].B
+l[02].a = L[02].A
+l[02].b = L[02].B
+l[03].a = L[03].A
+l[03].b = L[03].B
+
+mylist.01.prop1 = value-1-1
+mylist.01.prop2 = value-1-2
+mylist.02.prop1 = value-2-1
+mylist.02.prop2 = value-2-2

--- a/ant-mustache.template
+++ b/ant-mustache.template
@@ -1,0 +1,48 @@
+Hello,
+
+1. replace value:
+v = {{v}}
+k.v = {{k.v}}
+
+2. test
+mytrue? = {{mytrue?}}
+{{#mytrue?}}
+mytrue? is valid (not false nor empty list), showing this!
+{{/mytrue?}}
+{{^mytrue?}}
+mytrue? is NOT valid (false or empty list), showing that!
+{{/mytrue?}}
+
+myfalse? = {{myfalse?}}
+{{#myfalse?}}
+myfalse? is valid (not false nor empty list), showing this!
+{{/myfalse?}}
+{{^myfalse?}}
+myfalse? is NOT valid (false or empty list), showing that!
+{{/myfalse?}}
+
+{{#doesnotexist}}
+doesnotexist is valid (not false nor empty list), showing this!
+{{/doesnotexist}}
+{{^doesnotexist}}
+doesnotexist is NOT valid (false or empty list), showing that!
+{{/doesnotexist}}
+
+3. list
+{{#l}}
+__id__ = {{__id__}}
+a      = {{a}}
+b      = {{b}}
+{{/l}}
+{{^l}}
+l is empty or not set
+{{/l}}
+
+mylist = {{mylist}}
+{{#mylist}}
+{{__id__}}.prop1 = {{prop1}}
+{{__id__}}.prop2 = {{prop2}}
+{{/mylist}}
+
+4. direct access:
+l[02].b = {{l[02].b}}

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,34 @@
+<project name="mustache-ant-test" default="test">
+	
+	<target name="init">
+		<typedef name="mustache" classname="com.samskivert.mustache.ant.MustacheFilter">
+			<classpath>
+				<path location="target/classes" />
+			</classpath>
+		</typedef>
+		<property name="\n" value="${line.separator}" />
+	</target>
+	<target name="test" depends="init">
+		<loadfile property="expected">
+			<fileset file="ant-mustache.expected" />
+		</loadfile>
+
+		<loadfile property="test1.output">
+			<fileset file="ant-mustache.template" />
+			<filterchain>
+				<tokenfilter>
+					<filetokenizer />
+					<mustache projectProperties="false" dataFile="ant-mustache.properties" strictSections="false" />
+				</tokenfilter>
+			</filterchain>
+		</loadfile>
+		<loadfile property="expected">
+			<fileset file="ant-mustache.expected" />
+		</loadfile>
+		<fail message="test1 failed:${\n}output:${\n}${test1.output}${\n}${\n}Expected:${\n}${expected}">
+			<condition>
+				<not><equals arg1="${test1.output}" arg2="${expected}" /></not>
+			</condition>
+		</fail>
+		<property file="ant-mustache.properties" prefix="mustache" />	</target>
+	</project>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
    	  <groupId>org.apache.ant</groupId>
       <artifactId>ant-nodeps</artifactId>
       <version>1.7.0</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
       <version>1.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+    	<groupId>org.apache.ant</groupId>
+    	<artifactId>ant</artifactId>
+    	<version>1.7.0</version>
+    	<scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>org.apache.ant</groupId>
-    	<artifactId>ant</artifactId>
-    	<version>1.7.0</version>
-    	<scope>provided</scope>
+   	  <groupId>org.apache.ant</groupId>
+      <artifactId>ant-nodeps</artifactId>
+      <version>1.7.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/samskivert/mustache/ant/MustacheFilter.java
+++ b/src/main/java/com/samskivert/mustache/ant/MustacheFilter.java
@@ -68,8 +68,8 @@ public class MustacheFilter extends ChainableReaderFilter {
 	 * access the list. The second group is the id of this item in the list. The
 	 * third group is the sub-key to assign the value to.
 	 */
-	private String listRegex = "(.+)\\.(\\d+)\\.(.+)";
-	// other example of regex: (.+)\[(\d+)\]\.(.+)
+	private String listRegex = "(.+?)\\.(\\d+)\\.(.+)";
+	// other example of regex: (.+?)\[(\d+)\]\.(.+)
 
 	/**
 	 * A file name from which data model properties should be loaded from.
@@ -98,72 +98,36 @@ public class MustacheFilter extends ChainableReaderFilter {
 	 */
 	private boolean escapeHTML = false;
 
-	public Boolean getProjectProperties() {
-		return projectProperties;
-	}
-
 	public void setProjectProperties(Boolean projectProperties) {
 		this.projectProperties = projectProperties;
-	}
-
-	public String getPrefix() {
-		return prefix;
 	}
 
 	public void setPrefix(String prefix) {
 		this.prefix = prefix;
 	}
 
-	public Boolean getRemovePrefix() {
-		return removePrefix;
-	}
-
 	public void setRemovePrefix(Boolean removePrefix) {
 		this.removePrefix = removePrefix;
-	}
-
-	public Boolean getSupportLists() {
-		return supportLists;
 	}
 
 	public void setSupportLists(Boolean supportLists) {
 		this.supportLists = supportLists;
 	}
 
-	public String getListIdName() {
-		return listIdName;
-	}
-
 	public void setListIdName(String listIdName) {
 		this.listIdName = listIdName;
-	}
-
-	public String getDataFile() {
-		return dataFile;
 	}
 
 	public void setDataFile(String dataFile) {
 		this.dataFile = dataFile;
 	}
 
-	public String getDefaultValue() {
-		return defaultValue;
-	}
-
 	public void setDefaultValue(String defaultValue) {
 		this.defaultValue = defaultValue;
 	}
 
-	public boolean isStrictSections() {
-		return strictSections;
-	}
-
 	public void setStrictSections(boolean strictSections) {
 		this.strictSections = strictSections;
-	}
-
-	public boolean isEscapeHTML() {
-		return escapeHTML;
 	}
 
 	public void setEscapeHTML(boolean escapeHTML) {

--- a/src/main/java/com/samskivert/mustache/ant/MustacheFilter.java
+++ b/src/main/java/com/samskivert/mustache/ant/MustacheFilter.java
@@ -1,0 +1,246 @@
+package com.samskivert.mustache.ant;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Vector;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.filters.TokenFilter.ChainableReaderFilter;
+import org.apache.tools.ant.types.RegularExpression;
+import org.apache.tools.ant.util.regexp.Regexp;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+public class MustacheFilter extends ChainableReaderFilter {
+
+	private Boolean projectProperties = true;
+	private String prefix = null;
+	private Boolean removePrefix = false;
+	private Boolean supportLists = true;
+	private String listIdName = "__id__";
+	private String dataFile = null;
+	private String listRegex = "(.+)\\.(\\d+)\\.(.+)";
+	// other example of regex: (.+)\[(\d+)\]\.(.+)
+
+	// JMustache settings
+	private String defaultValue = null;
+	private boolean strictSections = false;
+	private boolean escapeHTML = false;
+
+	public Boolean getProjectProperties() {
+		return projectProperties;
+	}
+
+	public void setProjectProperties(Boolean projectProperties) {
+		this.projectProperties = projectProperties;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public Boolean getRemovePrefix() {
+		return removePrefix;
+	}
+
+	public void setRemovePrefix(Boolean removePrefix) {
+		this.removePrefix = removePrefix;
+	}
+
+	public Boolean getSupportLists() {
+		return supportLists;
+	}
+
+	public void setSupportLists(Boolean supportLists) {
+		this.supportLists = supportLists;
+	}
+
+	public String getListIdName() {
+		return listIdName;
+	}
+
+	public void setListIdName(String listIdName) {
+		this.listIdName = listIdName;
+	}
+
+	public String getDataFile() {
+		return dataFile;
+	}
+
+	public void setDataFile(String dataFile) {
+		this.dataFile = dataFile;
+	}
+
+	public String getDefaultValue() {
+		return defaultValue;
+	}
+
+	public void setDefaultValue(String defaultValue) {
+		this.defaultValue = defaultValue;
+	}
+
+	public boolean isStrictSections() {
+		return strictSections;
+	}
+
+	public void setStrictSections(boolean strictSections) {
+		this.strictSections = strictSections;
+	}
+
+	public boolean isEscapeHTML() {
+		return escapeHTML;
+	}
+
+	public void setEscapeHTML(boolean escapeHTML) {
+		this.escapeHTML = escapeHTML;
+	}
+
+	public void setListRegex(String listRegex) {
+		this.listRegex = listRegex;
+	}
+
+	public String filter(String text) {
+		getProject().log("Mustache DataModel: " + getDataModel().toString(),
+				Project.MSG_DEBUG);
+		Template tmpl = Mustache.compiler().defaultValue(defaultValue)
+				.strictSections(strictSections).escapeHTML(escapeHTML)
+				.compile(text);
+		return tmpl.execute(getDataModel());
+	}
+
+	private Map<String, Object> _dataModel = null;
+
+	private Map<String, Object> getDataModel() {
+		if (_dataModel == null) {
+			_dataModel = new HashMap<String, Object>();
+			addProjectProperties();
+			addSrcFile();
+		}
+		return _dataModel;
+	}
+
+	private void addProjectProperties() {
+		if (projectProperties) {
+			addProperties(getProject().getProperties(), prefix, removePrefix);
+		}
+	}
+
+	private void addSrcFile() {
+		if (dataFile != null) {
+			Properties props = new Properties();
+			try {
+				props.load(new FileInputStream(dataFile));
+			} catch (IOException e) {
+				throw new BuildException(e);
+			}
+			addProperties(props, null, false);
+		}
+	}
+
+	private void addProperties(Hashtable<?, ?> props, String prefix,
+			Boolean removePrefix) {
+		Iterator<?> it = props.keySet().iterator();
+		while (it.hasNext()) {
+			String key = (String) it.next();
+			if (prefix == null || key.startsWith(prefix)) {
+				Object value = computeValue(key, props.get(key));
+				if (removePrefix && prefix != null) {
+					key = key.substring(prefix.length());
+				}
+				add(_dataModel, key, value);
+			}
+		}
+	}
+
+	private Map<String, Object> add(Map<String, Object> map, String key,
+			Object value) {
+		map.put(key, value);
+		handleList(map, key, value);
+		return map;
+	}
+
+	private void handleList(Map<String, Object> map, String key, Object value) {
+		if (supportLists && getListRegex().matches(key)) {
+			ListKeyParser parser = new ListKeyParser(key);
+			addList(map, parser.rootKey, parser.id, parser.subKey, value);
+		}
+	}
+
+	private void addList(Map<String, Object> map, String rootKey, String id,
+			String subKey, Object value) {
+		List<Map<String, Object>> listContext = (List<Map<String, Object>>) map
+				.get(rootKey);
+		if (listContext == null) {
+			listContext = new ArrayList<Map<String, Object>>();
+			map.put(rootKey, listContext);
+		}
+
+		Map<String, Object> foundMap = null;
+		for (Map<String, Object> subMap : listContext) {
+			if (id.equals(subMap.get(listIdName))) {
+				foundMap = subMap;
+				break;
+			}
+		}
+		if (foundMap == null) {
+			foundMap = new HashMap<String, Object>();
+			foundMap.put(listIdName, id);
+			listContext.add(foundMap);
+			Collections.sort(listContext,
+					new Comparator<Map<String, Object>>() {
+						public int compare(Map<String, Object> m1,
+								Map<String, Object> m2) {
+							return ((String) m1.get(listIdName))
+									.compareTo((String) m2.get(listIdName));
+						}
+					});
+		}
+		add(foundMap, subKey, value);
+	}
+
+	private Regexp _listRegexp = null;
+
+	private Regexp getListRegex() {
+		if (_listRegexp == null) {
+			RegularExpression _listRegularExpression = new RegularExpression();
+			_listRegularExpression.setPattern(listRegex);
+			_listRegexp = _listRegularExpression.getRegexp(getProject());
+		}
+		return _listRegexp;
+	}
+
+	private class ListKeyParser {
+		public String rootKey = null;
+		public String id = null;
+		public String subKey = null;
+
+		public ListKeyParser(String key) {
+			Vector<?> groups = getListRegex().getGroups(key);
+			rootKey = (String) groups.get(1);
+			id = (String) groups.get(2);
+			subKey = (String) groups.get(3);
+		}
+	}
+
+	private Object computeValue(String key, Object value) {
+		if (key.endsWith("?") && "false".equals(value)) {
+			return false;
+		}
+		return value;
+	}
+}

--- a/src/main/java/com/samskivert/mustache/ant/README.md
+++ b/src/main/java/com/samskivert/mustache/ant/README.md
@@ -46,7 +46,7 @@ All parameters are optional.
 | removePrefix      | Boolean: should we remove the prefix (if specified) from the property name?   | false          |
 | supportLists      | Boolean. Adds list support (see below)                                        | true           |
 | listRegex         | The regex pattern to use to defined lists (see below)                   | (.*)\\.(\\d+)\\.(.*) |
-| listIdName        | The name of the list id to be generated (see below)                           | __id__         |
+| listIdName        | The name of the list id to be generated (see below)                           | \__id__         |
 | dataFile          | A property file containing datamodel key and values                           | None           |
 | defaultValue      | As JMustache defaultValue(), provides a default to non-defined keys | No default, fails on missing|
 | strictSections    | As JMustache strictSections(), defines if section referring to a non-defined value should fail | false |
@@ -61,30 +61,32 @@ Provided property names can be parsed to generate lists. The default Regexp patt
 
 This pattern means that any property containing a number between two dots would be translated into a list.
 The list name is the first part.
-The id in the list is the number. It can be accessed using the value of listIdName (__id__ by default).
+The id in the list is the number. It can be accessed using the value of listIdName ("\__id__" by default).
 The remaining part is then used as a key inside the list.
 
 An example may help here. Consider the following properties:
 
-	mylist.01.prop1 = value 01-1
-	mylist.01.prop2 = value 01-2
-	mylist.02.prop1 = value 02-1
-	mylist.02.prop2 = value 02-2
+	mylist.01.prop1 = value-1-1
+	mylist.01.prop2 = value-1-2
+	mylist.02.prop1 = value-2-1
+	mylist.02.prop2 = value-2-2
 	
 And this template
 
+	mylist = {{mylist}}
 	{{#mylist}}
-	{{prop1}}
-	{{prop2}}
+	{{__id__}}.prop1 = {{prop1}}
+	{{__id__}}.prop2 = {{prop2}}
 	{{/mylist}}
 	
 The output would be:
 
-	value 01-1
-	value 01-2
-	value 02-1
-	value 02-2
-
+	mylist = [{prop2=value-1-2, prop1=value-1-1, __id__=01}, {prop2=value-2-2, prop1=value-2-1, __id__=02}]
+	01.prop1 = value-1-1
+	01.prop2 = value-1-2
+	02.prop1 = value-2-1
+	02.prop2 = value-2-2
+   
 Note that you can override the default pattern. For example, you may prefer to use a notation with square brackets:
 
 	listRegex="(.+)\[(\d+)\]\.(.+)"
@@ -107,6 +109,7 @@ Properties ending by a question mark are treated as Booleans, specifically to be
 	
 In the template:
 
+	mytrue? = {{mytrue?}}
 	{{#mytrue?}}
 	mytrue is valid (not false nor empty list), showing this!
 	{{/mytrue?}}

--- a/src/main/java/com/samskivert/mustache/ant/README.md
+++ b/src/main/java/com/samskivert/mustache/ant/README.md
@@ -1,0 +1,132 @@
+This is an [Ant](http://ant.apache.org/) filter to compute [Mustache](http://mustache.github.io/) templates based on [JMustache](https://github.com/samskivert/jmustache).
+
+It is to be used in a [Filterchain](http://ant.apache.org/manual/Types/filterchain.html) - [TokenFilter](http://ant.apache.org/manual/Types/filterchain.html#tokenfilter) using the [FileTokenizer](http://ant.apache.org/manual/Types/filterchain.html#filetokenizer).
+
+Installation
+============
+
+Download the JMustache jar file and store it somewhere accessible.
+You can then define the mustache filter in your ant script as follows:
+
+	<typedef name="mustache" classname="com.samskivert.mustache.ant.MustacheFilter">
+		<classpath>
+			<path location="${jmustache.jar}" />
+		</classpath>
+	</typedef>
+
+Usage
+=====
+
+This filter must be used inside a filetokenizer tokenfilter as it needs to parse the whole file at once:
+
+	<filterchain>
+		<tokenfilter>
+			<filetokenizer />
+			<mustachefilter />
+		</tokenfilter>
+	</filterchain>
+
+As this is a filter, it can be used in any Ant task supporting filterchains, like
+* Concat
+* Copy
+* LoadFile
+* LoadProperties
+* LoadResource
+* Move
+
+Parameters
+==========
+
+All parameters are optional.
+
+| Parameter         | Description                                                                   | Default        |
+|-------------------|-------------------------------------------------------------------------------|----------------|
+| projectProperties | Boolean (true or false): should project properties be added to the data model | true           |
+| prefix            | Only project properties starting with this prefix will be used                | No prefix used |
+| removePrefix      | Boolean: should we remove the prefix (if specified) from the property name?   | false          |
+| supportLists      | Boolean. Adds list support (see below)                                        | true           |
+| listRegex         | The regex pattern to use to defined lists (see below)                   | (.*)\\.(\\d+)\\.(.*) |
+| listIdName        | The name of the list id to be generated (see below)                           | __id__         |
+| dataFile          | A property file containing datamodel key and values                           | None           |
+| defaultValue      | As JMustache defaultValue(), provides a default to non-defined keys | No default, fails on missing|
+| strictSections    | As JMustache strictSections(), defines if section referring to a non-defined value should fail | false |
+| escapeHTML        | As JMustache escapeHTML(), defines if outputed HTML should be escaped         | false          |
+
+Lists support
+=============
+
+Provided property names can be parsed to generate lists. The default Regexp pattern for such property is
+
+	(.+)\\.(\\d+)\\.(.+)
+
+This pattern means that any property containing a number between two dots would be translated into a list.
+The list name is the first part.
+The id in the list is the number. It can be accessed using the value of listIdName (__id__ by default).
+The remaining part is then used as a key inside the list.
+
+An example may help here. Consider the following properties:
+
+	mylist.01.prop1 = value 01-1
+	mylist.01.prop2 = value 01-2
+	mylist.02.prop1 = value 02-1
+	mylist.02.prop2 = value 02-2
+	
+And this template
+
+	{{#mylist}}
+	{{prop1}}
+	{{prop2}}
+	{{/mylist}}
+	
+The output would be:
+
+	value 01-1
+	value 01-2
+	value 02-1
+	value 02-2
+
+Note that you can override the default pattern. For example, you may prefer to use a notation with square brackets:
+
+	listRegex="(.+)\[(\d+)\]\.(.+)"
+
+With such regex, the previous list would be written
+
+	mylist[01].prop1 = value 01-1
+	mylist[01].prop2 = value 01-2
+	mylist[02].prop1 = value 02-1
+	mylist[02].prop2 = value 02-2
+
+Boolean values
+==============
+
+As the string "false" is not usually considered as actually False, a special treatment is needed for booleans.
+Properties ending by a question mark are treated as Booleans, specifically to be used as tests inside the templates.
+
+	mytrue? = true
+	myfalse? = false
+	
+In the template:
+
+	{{#mytrue?}}
+	mytrue is valid (not false nor empty list), showing this!
+	{{/mytrue?}}
+	{{^mytrue?}}
+	mytrue is NOT valid (false or empty list), showing that!
+	{{/mytrue?}}
+	
+	myfalse? = {{myfalse?}}
+	{{#myfalse?}}
+	myfalse is valid (not false nor empty list), showing this!
+	{{/myfalse?}}
+	{{^myfalse?}}
+	myfalse is NOT valid (false or empty list), showing that!
+	{{/myfalse?}}
+
+Which outputs:
+
+	mytrue? = true
+	mytrue? is valid (not false nor empty list), showing this!
+	myfalse? = false
+	myfalse? is NOT valid (false or empty list), showing that!
+
+

--- a/src/main/java/com/samskivert/mustache/ant/README.md
+++ b/src/main/java/com/samskivert/mustache/ant/README.md
@@ -45,7 +45,7 @@ All parameters are optional.
 | prefix            | Only project properties starting with this prefix will be used                | No prefix used |
 | removePrefix      | Boolean: should we remove the prefix (if specified) from the property name?   | false          |
 | supportLists      | Boolean. Adds list support (see below)                                        | true           |
-| listRegex         | The regex pattern to use to defined lists (see below)                   | (.*)\\.(\\d+)\\.(.*) |
+| listRegex         | The regex pattern to use to defined lists (see below)                   | (.+)\\.(\\d+)\\.(.+) |
 | listIdName        | The name of the list id to be generated (see below)                           | \__id__         |
 | dataFile          | A property file containing datamodel key and values                           | None           |
 | defaultValue      | As JMustache defaultValue(), provides a default to non-defined keys | No default, fails on missing|

--- a/src/main/java/com/samskivert/mustache/ant/README.md
+++ b/src/main/java/com/samskivert/mustache/ant/README.md
@@ -22,7 +22,7 @@ This filter must be used inside a filetokenizer tokenfilter as it needs to parse
 	<filterchain>
 		<tokenfilter>
 			<filetokenizer />
-			<mustachefilter />
+			<mustache />
 		</tokenfilter>
 	</filterchain>
 

--- a/src/main/java/com/samskivert/mustache/ant/README.md
+++ b/src/main/java/com/samskivert/mustache/ant/README.md
@@ -45,7 +45,7 @@ All parameters are optional.
 | prefix            | Only project properties starting with this prefix will be used                | No prefix used |
 | removePrefix      | Boolean: should we remove the prefix (if specified) from the property name?   | false          |
 | supportLists      | Boolean. Adds list support (see below)                                        | true           |
-| listRegex         | The regex pattern to use to defined lists (see below)                   | (.+)\\.(\\d+)\\.(.+) |
+| listRegex         | The regex pattern to use to defined lists (see below)                   | (.+?)\\.(\\d+)\\.(.+) |
 | listIdName        | The name of the list id to be generated (see below)                           | \__id__         |
 | dataFile          | A property file containing datamodel key and values                           | None           |
 | defaultValue      | As JMustache defaultValue(), provides a default to non-defined keys | No default, fails on missing|
@@ -57,7 +57,7 @@ Lists support
 
 Provided property names can be parsed to generate lists. The default Regexp pattern for such property is
 
-	(.+)\\.(\\d+)\\.(.+)
+	(.+?)\\.(\\d+)\\.(.+)
 
 This pattern means that any property containing a number between two dots would be translated into a list.
 The list name is the first part.
@@ -89,7 +89,7 @@ The output would be:
    
 Note that you can override the default pattern. For example, you may prefer to use a notation with square brackets:
 
-	listRegex="(.+)\[(\d+)\]\.(.+)"
+	listRegex="(.+?)\[(\d+)\]\.(.+)"
 
 With such regex, the previous list would be written
 

--- a/src/test/java/com/samskivert/mustache/ant/MustacheFilterTest.java
+++ b/src/test/java/com/samskivert/mustache/ant/MustacheFilterTest.java
@@ -1,0 +1,114 @@
+//
+// JMustache - A Java implementation of the Mustache templating language
+// http://github.com/samskivert/jmustache/blob/master/LICENSE
+
+package com.samskivert.mustache.ant;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.tools.ant.Project;
+import org.junit.Test;
+
+/**
+ * Various unit tests.
+ */
+public class MustacheFilterTest {
+
+	@Test
+	public void testSimpleVariable() {
+		test(new MustacheFilter(), "{{foo}}", "bar", context("foo", "bar"));
+	}
+
+	@Test
+	public void testPrefixRemoved() {
+		test(get("myprefix.", true), "{{foo}}", "bar",
+				context("myprefix.foo", "bar", "foo", "IGNORED"));
+	}
+
+	@Test
+	public void testBooleanTrue() {
+		test(new MustacheFilter(),
+				"{{#foo?}}foo? is True{{/foo?}}{{^foo?}}foo? is False{{/foo?}}",
+				"foo? is True", context("foo?", "true"));
+	}
+
+	@Test
+	public void testBooleanFalse() {
+		test(new MustacheFilter(),
+				"{{#foo?}}foo? is True{{/foo?}}{{^foo?}}foo? is False{{/foo?}}",
+				"foo? is False", context("foo?", "false"));
+	}
+
+	@Test
+	public void testBooleanAny() {
+		test(new MustacheFilter(),
+				"{{#foo?}}foo? is {{foo?}}{{/foo?}}{{^foo?}}foo? is False{{/foo?}}",
+				"foo? is MyValue", context("foo?", "MyValue"));
+	}
+
+	@Test
+	public void testList() {
+		test(new MustacheFilter(),
+				"{{#mylist}}{{__id__}}: {{p1}}-{{p2}}\n{{/mylist}}",
+				"1: 1.1-1.2\n2: 2.1-2.2\n",
+				context("mylist.1.p1", "1.1", "mylist.1.p2", "1.2",
+						"mylist.2.p1", "2.1", "mylist.2.p2", "2.2"));
+	}
+
+	@Test
+	public void testImbricatedList() {
+		test(new MustacheFilter(),
+				"{{#mylist1}}{{#mylist2}}{{p1}}-{{p2}}\n{{/mylist2}}{{/mylist1}}",
+				"1.1.1-1.1.2\n1.2.1-1.2.2\n2.1.1-2.1.2\n2.2.1-2.2.2\n",
+				context("mylist1.1.mylist2.1.p1", "1.1.1", "mylist1.1.mylist2.1.p2", "1.1.2",
+						"mylist1.1.mylist2.2.p1", "1.2.1", "mylist1.1.mylist2.2.p2", "1.2.2",
+						"mylist1.2.mylist2.1.p1", "2.1.1", "mylist1.2.mylist2.1.p2", "2.1.2",
+						"mylist1.2.mylist2.2.p1", "2.2.1", "mylist1.2.mylist2.2.p2", "2.2.2"));
+	}
+
+	protected MustacheFilter get(String prefix, Boolean removePrefix) {
+		MustacheFilter m = new MustacheFilter();
+		if (prefix != null) {
+			m.setPrefix(prefix);
+		}
+		if (removePrefix != null) {
+			m.setRemovePrefix(removePrefix);
+		}
+		return m;
+	}
+
+	protected void test(MustacheFilter mustache, String template,
+			String expected, Map<String, String> context) {
+		Project project = new Project();
+		project.setProperty("ant.regexp.regexpimpl",
+				"org.apache.tools.ant.util.regexp.Jdk14RegexpRegexp");
+		if (context != null) {
+			for (Entry<String, String> entry : context.entrySet()) {
+				project.setProperty(entry.getKey(), entry.getValue());
+			}
+		}
+		mustache.setProject(project);
+		String output = mustache.filter(template);
+		check(expected, output);
+	}
+
+	protected void check(String expected, String output) {
+		assertEquals(uncrlf(expected), uncrlf(output));
+	}
+
+	protected static String uncrlf(String text) {
+		return text == null ? null : text.replace("\r", "\\r").replace("\n", "\\n");
+	}
+
+	protected Map<String, String> context(String... data) {
+		Map<String, String> ctx = new HashMap<String, String>();
+		for (int ii = 0; ii < data.length; ii += 2) {
+			ctx.put(data[ii], data[ii + 1]);
+		}
+		return ctx;
+	}
+}


### PR DESCRIPTION
This new class allows to use JMustache inside Ant scripts, using the Ant fitering capabilities. As far as I know there are no Ant support for Mustache templates out there.
Putting this class in JMustache directly would allow ant users to use a single jar to benefit from Mustache templating, which is one of the benefit of JMustache (no other dependencies). Up to you to see if you want to add this support in your project.
Note that ant.jar is needed at compile time for this new task (added in pom.xml). Of course not needed at runtime as already available within the ant execution context.
A README.md was created in the source to provide user install/usage guidance.