### PR TITLE
Fix broken test which depends on local timezone

### DIFF
--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
@@ -367,6 +368,9 @@ public class MustacheTest
                 else return String.valueOf(value);
             }
             protected SimpleDateFormat _fmt = new SimpleDateFormat("yyyy/MM/dd");
+            {
+                _fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
+            }
         };
         check("Date: 2014/01/08", Mustache.compiler().withFormatter(fmt).
               compile("{{msg}}: {{today}}").execute(new Object() {


### PR DESCRIPTION
On my machine, the test fails with the message:

```
[error] Test com.samskivert.mustache.MustacheTest.testCustomFormatter failed: expected:<Date: 2014/01/0[8]> but was:<Date: 2014/01/0[9]>
```

This patch explicitly sets TimeZone of DateFormat and fixes the problem.