### PR TITLE
Catch exceptions caused by fetching with invalid indices

### DIFF
--- a/src/main/java/com/samskivert/mustache/BasicCollector.java
+++ b/src/main/java/com/samskivert/mustache/BasicCollector.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * A collector that does not use reflection and can be used with GWT.
@@ -58,6 +59,8 @@ public abstract class BasicCollector implements Mustache.Collector
                 return ((List<?>)ctx).get(Integer.parseInt(name));
             } catch (NumberFormatException nfe) {
                 return Template.NO_FETCHER_FOUND;
+            } catch (IndexOutOfBoundsException e) {
+                return Template.NO_FETCHER_FOUND;
             }
         }
     };
@@ -67,6 +70,8 @@ public abstract class BasicCollector implements Mustache.Collector
             try {
                 return ((Object[])ctx)[Integer.parseInt(name)];
             } catch (NumberFormatException nfe) {
+                return Template.NO_FETCHER_FOUND;
+            } catch (IndexOutOfBoundsException e) {
                 return Template.NO_FETCHER_FOUND;
             }
         }
@@ -79,6 +84,8 @@ public abstract class BasicCollector implements Mustache.Collector
                 for (int ii = 0, ll = Integer.parseInt(name); ii < ll; ii++) iter.next();
                 return iter.next();
             } catch (NumberFormatException nfe) {
+                return Template.NO_FETCHER_FOUND;
+            } catch (NoSuchElementException e) {
                 return Template.NO_FETCHER_FOUND;
             }
         }

--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -122,6 +122,11 @@ public class MustacheTest
             "foo", Arrays.asList(context("bar", "baz"), context("bar", "bif"))));
     }
 
+    @Test public void testListIndexOutOfBoundsSection () {
+        test("", "{{#foo.2}}{{bar}}{{/foo.2}}", context(
+                 "foo", Arrays.asList(context("bar", "baz"), context("bar", "bif"))));
+    }
+
     @Test public void testListItemSection() {
         test("baz", "{{foo.0.bar}}", context(
             "foo", Arrays.asList(context("bar", "baz"), context("bar", "bif"))));
@@ -137,6 +142,12 @@ public class MustacheTest
         test("baz", "{{#foo.0}}{{bar}}{{/foo.0}}",
             context("foo", new Object[] {
                 context("bar", "baz"), context("bar", "bif") }));
+    }
+
+    @Test public void testArrayIndexOutOfBoundsSection () {
+        test("", "{{#foo.2}}{{bar}}{{/foo.2}}",
+             context("foo", new Object[] {
+                     context("bar", "baz"), context("bar", "bif") }));
     }
 
     @Test public void testArrayItemSection () {
@@ -155,6 +166,12 @@ public class MustacheTest
         test("baz", "{{#foo.0}}{{bar}}{{/foo.0}}",
             context("foo", Arrays.asList(context("bar", "baz"),
                 context("bar", "bif")).iterator()));
+    }
+
+    @Test public void testIteratorIndexOutOfBoundsSection () {
+        test("", "{{#foo.2}}{{bar}}{{/foo.2}}",
+             context("foo", Arrays.asList(context("bar", "baz"),
+                                          context("bar", "bif")).iterator()));
     }
 
     @Test public void testIteratorItemSection () {


### PR DESCRIPTION
On jmustache v1.10, the code below throws `MustacheException$Context` caused by `ArrayIndexOutOfBoundsException`.

```java
Mustache.Compiler compiler = Mustache.compiler();
Template template = compiler.compile("{{foo.5}}");
String result = template.execute(new Object() {
    String[] foo = new String[]{"bar", "baz", "bif"};
});
```

This behavior may cause undesirable things such as application crashes.
IMO, the illegal index access should throw exceptions only when the user explicitly sets `strictSections(true)`, similar as the access on missing fields.