### PR TITLE
emptyStringIsFalse flag now works with any Object.

### DIFF
--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -203,7 +203,7 @@ public class Mustache {
           * then empty strings are considered falsey. If {@link #zeroIsFalse} is true, then zero
           * values are considered falsey. */
         public boolean isFalsey (Object value) {
-            return (emptyStringIsFalse && "".equals(value)) ||
+            return (emptyStringIsFalse && "".equals(formatter.format(value))) ||
             (zeroIsFalse && (value instanceof Number) && ((Number)value).longValue() == 0);
         }
 


### PR DESCRIPTION
Previously, only String types were checked for being empty. Now
the Formatter is used to format the Object before checking for
being empty.

Example of before change behaviour:
```
Mustache.Compiler compiler = Mustache.compiler().emptyStringIsFalse(true);
compiler.isFalsey(""); // true

Object myEmptyStrObj = new Object(){
    @Override
    public String toString() {
        return "";
    }
};
compiler.isFalsey(myEmptyStrObj); // false
```

After this change both `isFalsey` calls will return `true`;