### PR TITLE
Allows to understand tree structure from the Visitor interface

### DIFF
--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -370,6 +370,11 @@ public class Mustache {
           * @return true if the contents of the section should be visited, false to skip.
           */
         boolean visitInvertedSection (String name);
+
+        /** Inform that all section segments were visited.
+         * @param name the name of the section or inverted section.
+         */
+        void returnFromSection (String name);
     }
 
     /**
@@ -966,6 +971,7 @@ public class Mustache {
                 for (Template.Segment seg : _segs) {
                     seg.visit(visitor);
                 }
+                visitor.returnFromSection(_name);
             }
         }
         @Override public String toString () {
@@ -1011,6 +1017,7 @@ public class Mustache {
                 for (Template.Segment seg : _segs) {
                     seg.visit(visitor);
                 }
+                visitor.returnFromSection(_name);
             }
         }
         @Override public String toString () {

--- a/src/test/java/com/samskivert/mustache/SharedTests.java
+++ b/src/test/java/com/samskivert/mustache/SharedTests.java
@@ -357,6 +357,7 @@ public abstract class SharedTests extends GWTTestCase
         public boolean visitInclude (String name) { keys.add(name); return true; }
         public boolean visitSection (String name) { keys.add(name); return true; }
         public boolean visitInvertedSection (String name) { keys.add(name); return true; }
+        public void returnFromSection (String name) {}
     }
 
     @Test public void testVisit() {


### PR DESCRIPTION
I need to create a tree structure of the future template model before request it. Visitor interface almost suits this purpose, but I need to know when I should return back to the parent node.

It will be great if it can be useful to someone else. If you think it's not, just close the pull request.

Additional notes:
I can add  `returnFromInvertedSection` method or remove  `name` argument from `returnFromSection`.