### PR TITLE
Move .gitmodules from git protocol due to deprecation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/test/resources/specs"]
         path = src/test/resources/specs
-        url = git://github.com/mustache/spec.git
+        url = https://github.com/mustache/spec.git


### PR DESCRIPTION
This is related to:
- https://github.blog/2021-09-01-improving-git-protocol-security-github/
- https://blog.readthedocs.com/github-git-protocol-deprecation/