### PR TITLE
Add ability to pass CharSequence instead of forcing String for contex…

### DIFF
--- a/src/main/gwt/com/samskivert/super/java/io/Writer.java
+++ b/src/main/gwt/com/samskivert/super/java/io/Writer.java
@@ -9,4 +9,6 @@ package java.io;
 public abstract class Writer
 {
     public abstract void write (String text) throws IOException;
+
+    public abstract Writer append (CharSequence text) throws IOException;
 }

--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -203,8 +203,23 @@ public class Mustache {
           * then empty strings are considered falsey. If {@link #zeroIsFalse} is true, then zero
           * values are considered falsey. */
         public boolean isFalsey (Object value) {
-            return ((emptyStringIsFalse && "".equals(formatter.format(value))) ||
+            return ((emptyStringIsFalse && isEmptyCharSequence(formatter.format(value))) ||
                     (zeroIsFalse && (value instanceof Number) && ((Number)value).longValue() == 0));
+        }
+
+        /**
+         * Replaces "".equals(value). E.g. only not null values with length 0
+         */
+        private boolean isEmptyCharSequence(Object value) {
+            if (value == null) {
+                return false;
+            }
+
+            if(value instanceof CharSequence) {
+                return ((CharSequence) value).length() == 0;
+            }
+
+            return false;
         }
 
         /** Loads and compiles the template {@code name} using this compiler's configured template
@@ -255,8 +270,8 @@ public class Mustache {
     /** Handles converting objects to strings when rendering templates. */
     public interface Formatter {
 
-        /** Converts {@code value} to a string for inclusion in a template. */
-        String format (Object value);
+        /** Converts {@code value} to a CharSequence for inclusion in a template. */
+        CharSequence format (Object value);
     }
 
     /** Handles lambdas. */
@@ -295,6 +310,11 @@ public class Mustache {
 
         /** Returns {@code raw} with the appropriate characters replaced with escape sequences. */
         String escape (String raw);
+
+        /** Returns {@code raw} with the appropriate characters replaced with escape sequences. **/
+        default CharSequence escape (CharSequence raw) {
+            return escape(raw.toString());
+        }
     }
 
     /** Handles loading partial templates. */

--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -384,9 +384,9 @@ public class Template {
 
         abstract void visit (Mustache.Visitor visitor);
 
-        protected static void write (Writer out, String data) {
+        protected static void write (Writer out, CharSequence data) {
             try {
-                out.write(data);
+                out.append(data);
             } catch (IOException ioe) {
                 throw new MustacheException(ioe);
             }

--- a/src/test/java/com/samskivert/mustache/MustacheTest.java
+++ b/src/test/java/com/samskivert/mustache/MustacheTest.java
@@ -17,9 +17,6 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Mustache tests that can only be run on the JVM. Most tests should go in BaseMustacheTest so
@@ -52,6 +49,14 @@ public class MustacheTest extends SharedTests
                 return "foo".equals(name) ? "bar" : null;
             }
         });
+    }
+
+    @Test public void testCharSequenceVariable() {
+        Map<String, CharSequence> ctx = new HashMap<>();
+        StringBuffer stringBuffer = new StringBuffer();
+        stringBuffer.append("bar");
+        ctx.put("foo", stringBuffer);
+        test("bar", "{{foo}}", ctx);
     }
 
     public interface HasDefault {


### PR DESCRIPTION
**Background**
As part of security requirements - to avoid leaving traces of very sensitive data in memory, we are trying to clear memory as much as it is possible. All instances of java.lang.String are immutable and stay in memory until Garbage Collector deletes them.

**Solution**
Avoid needlessly calling .toString() or using java.lang.String in context and rely on CharSequence interface that can be passed to java.io.Writter
