### PR TITLE
Fix nested partial indentation and custom spec tests

### DIFF
--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -176,32 +176,11 @@ public class Template {
         if (indent.equals("")) {
             return this;
         }
-        Segment[] copySegs = indentSegs(_segs, indent);
+        Segment[] copySegs = Mustache.indentSegs(_segs, indent);
         if (copySegs == _segs) {
             return this;
         }
         return new Template(copySegs, _compiler);
-    }
-    
-    static Segment[] indentSegs(Segment[] _segs, String indent) {
-        if (indent.equals("")) {
-            return _segs;
-        }
-        int length = _segs.length;
-        Segment[] copySegs = new Segment[length];
-        boolean changed = false;
-        for (int i = 0; i < _segs.length; i++) {
-            Segment seg = _segs[i];
-            Segment copy = seg.indent(indent, i == (length - 1));
-            if (copy != seg) {
-                changed = true;
-            }
-            copySegs[i] = copy;
-        }
-        if (changed) {
-            return copySegs;
-        }
-        return _segs;
     }
 
     protected void executeSegs (Context ctx, Writer out) throws MustacheException {
@@ -422,8 +401,28 @@ public class Template {
         abstract void decompile (Mustache.Delims delims, StringBuilder into);
 
         abstract void visit (Mustache.Visitor visitor);
-        
-        abstract Segment indent(String indent, boolean last);
+        /**
+         * Recursively indent by the parameter indent.
+         * @param indent should be space characters that are not \n
+         * @param first append indent to the first line (regardless if it has a \n or not)
+         * @param last append indent on the last \n that has no text after it
+         * @return newly crated segment or the same segment if nothing changed.
+         */
+        abstract Segment indent(String indent, boolean first, boolean last);
+        /**
+         * Whether or not the segment is standalone.
+         * For blocks this is based on the closing tag.
+         * Once Trim is called standalone tags are determined so
+         * that proper (re)indentation will work without reparsing
+         * the template.
+         * 
+         * String and variable tags are never standalone.
+         * 
+         * The definition of standalone is defined by the mustache spec.
+         * 
+         * @return true if the tag is standalone
+         */
+        abstract boolean isStandalone();
 
         protected static void write (Writer out, CharSequence data) {
             try {

--- a/src/test/java/com/samskivert/mustache/SharedTests.java
+++ b/src/test/java/com/samskivert/mustache/SharedTests.java
@@ -257,15 +257,15 @@ public abstract class SharedTests
         }), "\\\n |\n <\n->\n |\n/\n", "\\\n {{>partial}}\n/\n", context("content", "<\n->"));
     }
 
-    @Ignore @Test public void testPartialBlankLines () {
+    @Test public void testPartialBlankLines () {
         test(Mustache.compiler().withLoader(new Mustache.TemplateLoader() {
             public Reader getTemplate (String name) {
                 return new StringReader("|\na\n\nb\n|\n");
             }
-        }), "\\\n\t|\n\ta\n\n\tb\n\t|\n/\n", "\\\n\t{{>partial}}\n/\n", context());
+        }), "\\\n\t|\n\ta\n\t\n\tb\n\t|\n/\n", "\\\n\t{{>partial}}\n/\n", context());
     }
 
-    @Ignore @Test public void testNestedPartialBlankLines () {
+    @Test public void testNestedPartialBlankLines () {
         test(Mustache.compiler().withLoader(new Mustache.TemplateLoader() {
             public Reader getTemplate (String name) {
                 if (name.equals("partial")) {
@@ -274,10 +274,10 @@ public abstract class SharedTests
                     return new StringReader("2\na\n\nb\n2\n");
                 }
             }
-        }), "\\\n\t1\n\t\t2\n\t\ta\n\n\t\tb\n\t\t2\n\t1\n/\n", "\\\n\t{{>partial}}\n/\n", context());
+        }), "\\\n\t1\n\t\t2\n\t\ta\n\t\t\n\t\tb\n\t\t2\n\t1\n/\n", "\\\n\t{{>partial}}\n/\n", context());
     }
 
-    @Ignore @Test public void testNestedPartialBlankLinesCRLF () {
+    @Test public void testNestedPartialBlankLinesCRLF () {
         test(Mustache.compiler().withLoader(new Mustache.TemplateLoader() {
             public Reader getTemplate (String name) {
                 if (name.equals("partial")) {
@@ -286,10 +286,10 @@ public abstract class SharedTests
                     return new StringReader("2\r\na\r\n\r\nb\r\n2\r\n");
                 }
             }
-        }), "\\\r\n\t1\r\n\t\t2\r\n\t\ta\r\n\r\n\t\tb\r\n\t\t2\r\n\t1\r\n/\r\n", "\\\r\n\t{{>partial}}\r\n/\r\n", context());
+        }), "\\\r\n\t1\r\n\t\t2\r\n\t\ta\r\n\t\t\r\n\t\tb\r\n\t\t2\r\n\t1\r\n/\r\n", "\\\r\n\t{{>partial}}\r\n/\r\n", context());
     }
 
-    /* @Ignore */ @Test public void testNestedPartialIndent () {
+    @Test public void testNestedPartialIndent () {
         Mustache.TemplateLoader loader = partials(entry("partial", "1\n {{>nest}}\n1\n"), entry("nest", "2\n{{{content}}}\n2\n"));
         test(Mustache.compiler().withLoader(loader), 
                 "|\n 1\n  2\n  <\n->\n  2\n 1\n|\n", 

--- a/src/test/java/com/samskivert/mustache/specs/CustomSpecTest.java
+++ b/src/test/java/com/samskivert/mustache/specs/CustomSpecTest.java
@@ -1,0 +1,24 @@
+package com.samskivert.mustache.specs;
+
+import java.util.Collection;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class CustomSpecTest extends SpecTest {
+
+    public CustomSpecTest(Spec spec, String name) {
+        super(spec, name);
+    }
+    
+    @Parameters(name = "{1}")
+    public static Collection<Object[]> data () {
+        String[] groups = new String[] {
+            "partials"
+        };
+        return SpecTest.data("/custom/specs/", groups);
+    }
+
+}

--- a/src/test/java/com/samskivert/mustache/specs/OfficialSpecTest.java
+++ b/src/test/java/com/samskivert/mustache/specs/OfficialSpecTest.java
@@ -1,0 +1,29 @@
+package com.samskivert.mustache.specs;
+
+import java.util.Collection;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class OfficialSpecTest extends SpecTest {
+
+    public OfficialSpecTest(Spec spec, String name) {
+        super(spec, name);
+    }
+
+    @Parameters(name = "{1}")
+    public static Collection<Object[]> data () {
+        String[] groups = new String[] {
+            "comments",
+            "delimiters",
+            "interpolation",
+            "inverted",
+            "sections",
+            "partials"
+        };
+        return SpecTest.data("/specs/specs/", groups);
+    }
+    
+}

--- a/src/test/java/com/samskivert/mustache/specs/Spec.java
+++ b/src/test/java/com/samskivert/mustache/specs/Spec.java
@@ -5,6 +5,7 @@
 package com.samskivert.mustache.specs;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * @author Yoryos Valotasios
@@ -26,7 +27,7 @@ public class Spec
     }
 
     public String getDescription () {
-        return (String) map.get("descr");
+        return (String) map.get("desc");
     }
 
     public String getTemplate () {
@@ -43,5 +44,21 @@ public class Spec
 
     public String getPartial (String name) {
         return partials == null ? null : partials.get(name);
+    }
+    
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        Consumer<String> value = s -> sb.append("\"").append(s).append("\"").append("\n");
+        Consumer<String> label = s -> sb.append("").append(s).append(": ");
+        label.accept("name");
+        value.accept(getName());
+        label.accept("desc");
+        value.accept(getDescription());
+        label.accept("template");
+        value.accept(getTemplate());
+        label.accept("expected");
+        value.accept(getExpectedOutput());
+        return sb.toString();
     }
 }

--- a/src/test/java/com/samskivert/mustache/specs/SpecAwareTemplateLoader.java
+++ b/src/test/java/com/samskivert/mustache/specs/SpecAwareTemplateLoader.java
@@ -12,9 +12,10 @@ import com.samskivert.mustache.Mustache;
 public class SpecAwareTemplateLoader implements Mustache.TemplateLoader
 {
     private static final String EMPTY_STRING = "";
-    private Spec spec;
+    private final Spec spec;
 
-    public void setSpec (Spec spec) {
+    public SpecAwareTemplateLoader(Spec spec) {
+        super();
         this.spec = spec;
     }
 

--- a/src/test/resources/custom/specs/partials.yml
+++ b/src/test/resources/custom/specs/partials.yml
@@ -1,0 +1,45 @@
+overview: |
+  Partial tags are used to expand an external template into the current
+  template.
+
+  The tag's content MUST be a non-whitespace character sequence NOT containing
+  the current closing delimiter.
+
+  This tag's content names the partial to inject.  Set Delimiter tags MUST NOT
+  affect the parsing of a partial.  The partial MUST be rendered against the
+  context stack local to the tag.  If the named partial cannot be found, the
+  empty string SHOULD be used instead, as in interpolations.
+
+  Partial tags SHOULD be treated as standalone when appropriate.  If this tag
+  is used standalone, any whitespace preceding the tag should treated as
+  indentation, and prepended to each line of the partial before rendering.
+tests:
+
+  - name: Nested Partial Indent
+    desc: "Nested partials should including the parent partials indent"
+    data: { content: "<\n->" }
+    template: "|\n {{>partial}}\n|\n"
+    partials:
+      partial: "1\n {{>nest}}\n1\n"
+      nest: "2\n{{{content}}}\n2\n"
+    expected: "|\n 1\n  2\n  <\n->\n  2\n 1\n|\n"
+
+  - name: Standalone Indentation
+    desc: Each line of the partial should be indented before rendering.
+    data: { content: "<\n->" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        {{{content}}}
+        |
+    expected: |
+      \
+       |
+       <
+      ->
+       |
+      /


### PR DESCRIPTION
@samskivert 

I fixed the previous nested indentation.

I'm sorry it took me longer than I promised.

I added custom spec tests in `src/main/resources/custom/spec`.

BTW this time I tried to sick more with the projects formatting.

What I plan on doing is eventually putting in the Eclipse Maven formatter plugin which I have used with great success in the past: https://code.revelc.net/formatter-maven-plugin/

(no it doesn't require Eclipse its just that Eclipse headless formatter is the most powerful one where as the others are opinionated).