### PR TITLE
Fix indentation with section segments

### DIFF
--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -176,7 +176,7 @@ public class Template {
         if (indent.equals("")) {
             return this;
         }
-        Segment[] copySegs = Mustache.indentSegs(_segs, indent);
+        Segment[] copySegs = Mustache.indentSegs(_segs, indent, false,false);
         if (copySegs == _segs) {
             return this;
         }

--- a/src/test/java/com/samskivert/mustache/specs/SpecTest.java
+++ b/src/test/java/com/samskivert/mustache/specs/SpecTest.java
@@ -31,7 +31,7 @@ public abstract class SpecTest {
     public void test () throws Exception {
         //System.out.println("Testing: " + name);
         SpecAwareTemplateLoader loader = new SpecAwareTemplateLoader(spec);
-        Mustache.Compiler compiler = Mustache.compiler().defaultValue("").withLoader(loader);
+        Mustache.Compiler compiler = Mustache.compiler().emptyStringIsFalse(true).defaultValue("").withLoader(loader);
         String tmpl = spec.getTemplate();
         String desc = String.format("Template: '''%s'''\nData: '%s'\n",
                                     uncrlf(tmpl), uncrlf(spec.getData().toString()));

--- a/src/test/resources/custom/specs/partials.yml
+++ b/src/test/resources/custom/specs/partials.yml
@@ -24,8 +24,8 @@ tests:
       nest: "2\n{{{content}}}\n2\n"
     expected: "|\n 1\n  2\n  <\n->\n  2\n 1\n|\n"
 
-  - name: Standalone Indentation
-    desc: Each line of the partial should be indented before rendering.
+  - name: Partial Section Indentation End Content
+    desc: Closing end sections that have content on same line should be indented
     data: { content: "<\n->" }
     template: |
       \
@@ -34,12 +34,83 @@ tests:
     partials:
       partial: |
         |
-        {{{content}}}
+        {{#content}}
+        {{{.}}}
+        {{/content}}-
         |
     expected: |
       \
        |
        <
       ->
+       -
        |
       /
+
+  - name: Partial Section Indentation Inside Start Content
+    desc: Content that is not white space on same line as section start tag inside should be indented
+    data: { content: "<\n->" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        {{#content}}-
+        {{{.}}}
+        {{/content}}
+        |
+    expected: |
+      \
+       |
+       -
+       <
+      ->
+       |
+      /
+
+  - name: Partial Section Indentation Start Content
+    desc: Content that is not white space on same line as section start tags should be indented
+    data: { content: "<\n->" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        -{{#content}}
+        {{{.}}}
+        {{/content}}
+        |
+    expected: |
+      \
+       |
+       -
+       <
+      ->
+       |
+      /
+
+  - name: Partial Indentation With Empty Sections
+    desc: Empty standlone sections should not have indentation before or after
+    data: { content: "" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        {{#content}}
+        {{{.}}}
+        {{/content}}
+        |
+    expected: |
+      \
+       |
+       |
+      /
+
+# The extra newline on the end is required


### PR DESCRIPTION
I fixed several problems with indentation and blocks (spec calls these sections). I confirmed that Wontache (spec playground implementation) produced the same output.