### PR TITLE
Partial thread safe (merge #154 first)

### DIFF
--- a/src/test/java/com/samskivert/mustache/PartialThreadSafeTest.java
+++ b/src/test/java/com/samskivert/mustache/PartialThreadSafeTest.java
@@ -1,0 +1,69 @@
+package com.samskivert.mustache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import com.samskivert.mustache.Mustache.TemplateLoader;
+
+public class PartialThreadSafeTest {
+    
+    @Test
+    public void testPartialThreadSafe() throws Exception {
+        long t = System.currentTimeMillis();
+        AtomicInteger loadCount = new AtomicInteger();
+        TemplateLoader loader = new TemplateLoader() {
+
+            @Override
+            public Reader getTemplate(String name) throws Exception {
+                if ("partial".equals(name)) {
+                    loadCount.incrementAndGet();
+                    TimeUnit.MILLISECONDS.sleep(20);
+                    return new StringReader("Hello");
+                }
+                throw new IOException(name);
+            }
+        };
+
+        Template template = Mustache.compiler().withLoader(loader).compile("{{stuff}}\n\t{{> partial }}");
+        ExecutorService executor = Executors.newFixedThreadPool(64);
+        ConcurrentLinkedDeque<Exception> q = new ConcurrentLinkedDeque<>();
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("stuff", "Foo");
+        for (int i = 100; i > 0; i--) {
+            int ii = i;
+            executor.execute(() -> {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(ii % 10);
+                    template.execute(m);
+                } catch (Exception e) {
+                    q.add(e);
+                }
+            });
+        }
+        executor.shutdown();
+        executor.awaitTermination(10_000, TimeUnit.MILLISECONDS);
+        if (!q.isEmpty()) {
+            System.out.println(q);
+        }
+        assertTrue(q.isEmpty());
+        assertEquals(1, loadCount.get());
+        System.out.println(loadCount);
+        System.out.println(System.currentTimeMillis() - t);
+
+    }
+
+}


### PR DESCRIPTION
@samskivert 

This PR builds on top of #154 . Merge that one first and I will rebase it on `master` and then you can merge it.

It fixes two problems:

* `_template` should be volatile regardless of locks
* a lock is used to load the partial template only once

Without the lock in a highly threaded environment the template can re-parsed an overwhelming amount of times.

For example the unit test code shows how the template can be loaded and parsed 63 times!

With the advent of Virtual Threads in JDK 21 you can have this happen way more often and if the template is coming from a database call this can be very expensive and outweighs the additional overhead of a lock (in almost all cases regardless of where the template comes from).

If you are wondering why `_template` never had threading problems (e.g. NPE on _template being `null`) not being `volatile` is because in 64 bit platforms all references are inherently atomic but this is not the case for 32 bit platforms like Raspberry PI or other JVM implementations.