### PR TITLE
Parent partial

### DIFF
--- a/src/main/java/com/samskivert/mustache/Mustache.java
+++ b/src/main/java/com/samskivert/mustache/Mustache.java
@@ -11,10 +11,14 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
+import com.samskivert.mustache.Template.Context;
+import com.samskivert.mustache.Template.Segment;
 
 /**
  * Provides <a href="http://mustache.github.com/">Mustache</a> templating services.
@@ -427,8 +431,8 @@ public class Mustache {
             boolean prevBlank = ((pseg == null && top) || (prev != null && prev.trailsBlank()));
             boolean nextBlank = ((nseg == null && top) || (next != null && next.leadsBlank()));
             // potentially trim around the open and close tags of a block segment
-            if (seg instanceof BlockSegment) {
-                BlockSegment block = (BlockSegment)seg;
+            if (seg instanceof AbstractSectionSegment) {
+                AbstractSectionSegment block = (AbstractSectionSegment)seg;
                 if (prevBlank && block.firstLeadsBlank()) {
                     if (pseg != null) segs[ii-1] = prev.trimTrailBlank();
                     block.trimFirstBlank();
@@ -451,10 +455,12 @@ public class Mustache {
                         include = include.indent(indent, pseg == null,nseg == null);
                         segs[ii] = include;
                     }
-                    //segs[ii-1] = prev.trimTrailBlank();
                     /*
                      * We trim the end because partials
-                     * follow standalone just like blocks
+                     * follow standalone just like blocks.
+                     * HOWEVER we do NOT trim the previous StringSegment
+                     * as it provides the partial indentation.
+                     * See indentSegs.
                      */
                     if (next != null) { 
                         segs[ii+1] = next.trimLeadBlank();
@@ -498,8 +504,8 @@ public class Mustache {
             Template.Segment nseg = (i < length - 1) ? _segs[i+1] : null;
             
             Template.Segment copy;
-            if (seg instanceof BlockSegment) {
-                BlockSegment bs = (BlockSegment) seg;
+            if (seg instanceof AbstractSectionSegment) {
+                AbstractSectionSegment bs = (AbstractSectionSegment) seg;
                 boolean first;
                 boolean last;
                 if (pseg == null) {
@@ -543,8 +549,8 @@ public class Mustache {
                 if (nseg == null) {
                     last = _last;
                 }
-                else if (nseg instanceof BlockSegment) {
-                    BlockSegment bs = (BlockSegment) nseg;
+                else if (nseg instanceof AbstractSectionSegment) {
+                    AbstractSectionSegment bs = (AbstractSectionSegment) nseg;
                     last = ! bs.isStandaloneStart();
                 }
                 else if (nseg.isStandalone()) {
@@ -587,6 +593,34 @@ public class Mustache {
             }
             else {
                 copy = seg.indent(indent, _first, _last);
+            }
+            if (copy != seg) {
+                changed = true;
+            }
+            copySegs[i] = copy;
+        }
+        if (changed) { 
+            return copySegs;
+        }
+        return _segs;
+    }
+    
+    static Template.Segment[] replaceBlockSegs(Template.Segment[] _segs, Map<String, BlockSegment> blocks) {
+        if (blocks.isEmpty()) {
+            return _segs;
+        }
+        int length = _segs.length;
+        Template.Segment[] copySegs = new Template.Segment[length];
+        boolean changed = false;
+        for (int i = 0; i < _segs.length; i++) {
+            Template.Segment seg = _segs[i];
+            Template.Segment copy;
+            if (seg instanceof BlockReplaceable) {
+                BlockReplaceable br = (BlockReplaceable) seg;
+                copy = br.replaceBlocks(blocks);
+            }
+            else {
+                copy = seg;
             }
             if (copy != seg) {
                 changed = true;
@@ -863,9 +897,34 @@ public class Mustache {
                 };
 
             case '>':
-                _segs.add(new IncludedTemplateSegment(_comp, tag1));
+                _segs.add(new IncludedTemplateSegment(_comp, tag1, tagLine));
                 return this;
-
+            case '<':
+                requireNoNewlines(tag, tagLine);
+                return new Accumulator(_comp, false) {
+                    @Override public Template.Segment[] finish () {
+                        throw new MustacheParseException(
+                            "Parent missing close tag '" + tag1 + "'", tagLine);
+                    }
+                    @Override protected Accumulator addCloseSectionSegment (String itag, int line) {
+                        requireSameName(tag1, itag, line);
+                        outer._segs.add(new ParentTemplateSegment(_comp, itag, super.finish(), tagLine));
+                        return outer;
+                    }
+                };
+            case '$':
+                requireNoNewlines(tag, tagLine);
+                return new Accumulator(_comp, false) {
+                    @Override public Template.Segment[] finish () {
+                        throw new MustacheParseException(
+                            "Block missing close tag '" + tag1 + "'", tagLine);
+                    }
+                    @Override protected Accumulator addCloseSectionSegment (String itag, int line) {
+                        requireSameName(tag1, itag, line);
+                        outer._segs.add(new BlockSegment(_comp, itag, super.finish(), tagLine));
+                        return outer;
+                    }
+                };
             case '^':
                 requireNoNewlines(tag, tagLine);
                 return new Accumulator(_comp, false) {
@@ -1033,30 +1092,19 @@ public class Mustache {
         protected final boolean _first;
     }
 
-    /** A segment that loads and executes a sub-template. */
-    protected static class IncludedTemplateSegment extends Template.Segment {
-        public IncludedTemplateSegment (Compiler compiler, String name) {
-            this(compiler, name, "");
-        }
-        private IncludedTemplateSegment (Compiler compiler, String name, String indent) {
+    /** An abstract segment that is a template include. */
+    protected static abstract class AbstractPartialSegment extends NamedSegment {
+        protected AbstractPartialSegment (Compiler compiler, String name, int line, String indent) {
+            super(name, line);
             _comp = compiler;
-            _name = name;
             _indent = indent;
         }
-        @Override public void execute (Template tmpl, Template.Context ctx, Writer out) {
+        @Override public final void execute (Template tmpl, Template.Context ctx, Writer out) {
             // we must take care to preserve our context rather than creating a new one, which
             // would happen if we just called execute() with ctx.data
             getTemplate().executeSegs(ctx, out);
         }
-        @Override public void decompile (Delims delims, StringBuilder into) {
-            delims.addTag('>', _name, into);
-        }
-        @Override public void visit (Visitor visitor) {
-            if (visitor.visitInclude(_name)) {
-                getTemplate().visit(visitor);
-            }
-        }
-        protected Template getTemplate () {
+        protected final Template getTemplate () {
             // we compile our template lazily to avoid infinie recursion if a template includes
             // itself (see issue #13)
             Template t = _template;
@@ -1066,7 +1114,7 @@ public class Mustache {
                 lock.lock();
                 try {
                     if ((t = _template) == null) {
-                        _template = t = _comp.loadTemplate(_name).indent(_indent);
+                        _template = t = _loadTemplate();
                     }
                 } finally {
                     lock.unlock();
@@ -1074,31 +1122,109 @@ public class Mustache {
             }
             return t;
         }
-        protected IncludedTemplateSegment indent(String indent, boolean first, boolean last) {
+        
+        protected Template _loadTemplate() {
+            return _comp.loadTemplate(_name).indent(_indent);
+        }
+        
+        @Override public abstract boolean isStandalone();
+
+        protected final Compiler _comp;
+        protected final String _indent;
+        private final Lock lock = new ReentrantLock();
+        private volatile Template _template;
+    }
+
+    /** A segment that loads and executes a sub-template by spec called a partial. */
+    protected static class IncludedTemplateSegment extends AbstractPartialSegment {
+        public IncludedTemplateSegment (Compiler compiler, String name, int line) {
+            this(compiler, name, line,"");
+        }
+        private IncludedTemplateSegment (Compiler compiler, String name, int line, String indent) {
+            super(compiler, name, line, indent);
+        }
+        @Override public void decompile (Delims delims, StringBuilder into) {
+            delims.addTag('<', _name, into);
+        }
+        @Override public void visit (Visitor visitor) {
+            if (visitor.visitInclude(_name)) {
+                getTemplate().visit(visitor);
+            }
+        }
+        @Override protected IncludedTemplateSegment indent(String indent, boolean first, boolean last) {
             // Indent this partial based on the spacing provided.
             // per the spec however much the partial reference is indendented (leading whitespace)
             // is how much the partial content should be indented.
             if (indent.equals("") || ! _standalone) {
                 return this;
             }
-            IncludedTemplateSegment is = new IncludedTemplateSegment(_comp, _name, indent + this._indent );
+            IncludedTemplateSegment is = new IncludedTemplateSegment(_comp, _name, _line, indent + this._indent );
             is._standalone = _standalone;
             return is;
         }
-        @Override boolean isStandalone() { return _standalone; }
 
-        @Override
-        public String toString() {
+        @Override public String toString() {
             return "Include(name=" + _name + ", indent=" + _indent + ", standalone=" + _standalone
                     + ")";
         }
+        @Override public boolean isStandalone() { return _standalone; }
+        protected boolean _standalone;
+    }
+    
+    /** A segment that loads and executes a parent template by spec called inheritance. */
+    protected static class ParentTemplateSegment extends AbstractPartialSegment implements StandaloneSection {
+        public ParentTemplateSegment (Compiler compiler, String name, Template.Segment[] segs, int line) {
+            this(compiler, name, segs, line, "");
+        }
+        private ParentTemplateSegment (Compiler compiler, String name, Template.Segment[] segs, int line, String indent) {
+            super(compiler, name, line, indent);
+            this._segs = segs;
+        }
+        @Override public void decompile (Delims delims, StringBuilder into) {
+            delims.addTag('<', _name, into);
+        }
+        @Override public void visit (Visitor visitor) {
+            if (visitor.visitInclude(_name)) {
+                getTemplate().visit(visitor);
+            }
+        }
+        @Override protected ParentTemplateSegment indent(String indent, boolean first, boolean last) {
+            // Indent this partial based on the spacing provided.
+            // per the spec however much the partial reference is indendented (leading whitespace)
+            // is how much the partial content should be indented.
+            if (indent.equals("") || ! _standaloneStart) {
+                return this;
+            }
+            ParentTemplateSegment is = new ParentTemplateSegment(_comp, _name, _segs, _line, indent + this._indent );
+            is._standaloneStart = _standaloneStart;
+            is._standaloneEnd = _standaloneEnd;
+            return is;
+        }
+        @Override protected Template _loadTemplate() {
+            // linked hash map is easier to debug as the blocks will be in order
+            // and since this is only used for compiling we do not care about perf.
+            Map<String, BlockSegment> blocks = new LinkedHashMap<>();
+            // While we capture other segments we only care about blocks.
+            for (Template.Segment seg : _segs) {
+                if (seg instanceof BlockSegment) {
+                    BlockSegment bs = (BlockSegment) seg;
+                    blocks.put(bs._name, bs);
+                }
+            }
+            return super._loadTemplate().replaceBlocks(blocks);
+        }
+        @Override public Template.Segment[] _segs() { return _segs; }
+        @Override public boolean isStandalone() { return _standaloneEnd; }
+        @Override public boolean isStandaloneStart() { return _standaloneStart; }
+        @Override public boolean isStandaloneEnd() { return _standaloneEnd; }
+        @Override public String toString() {
+            return "Parent(name=" + _name + ", indent=" + _indent + ", standaloneStart=" + _standaloneStart
+                    + ")";
+        }
+        protected final Template.Segment[] _segs;
+        protected boolean _standaloneStart = false;
+        protected boolean _standaloneEnd = false;
 
-        protected final Compiler _comp;
-        protected final String _name;
-        private final String _indent;
-        private final Lock lock = new ReentrantLock();
-        private volatile Template _template;
-        protected boolean _standalone = false;
     }
 
     /** A helper class for named segments. */
@@ -1149,32 +1275,48 @@ public class Mustache {
         protected final Escaper _escaper;
     }
 
-    /** A helper class for block segments. */
-    protected static abstract class BlockSegment extends NamedSegment {
-        public boolean firstLeadsBlank () {
+    protected interface StandaloneSection {
+        default boolean firstLeadsBlank () {
+            Template.Segment[] _segs = _segs();
             if (_segs.length == 0 || !(_segs[0] instanceof StringSegment)) return false;
             return ((StringSegment)_segs[0]).leadsBlank();
         }
-        public void trimFirstBlank () {
+        default void trimFirstBlank () {
+            Template.Segment[] _segs = _segs();
             _segs[0] = ((StringSegment)_segs[0]).trimLeadBlank();
         }
 
-        public boolean lastTrailsBlank () {
+        default boolean lastTrailsBlank () {
+            Template.Segment[] _segs = _segs();
             int lastIdx = _segs.length-1;
             if (_segs.length == 0 || !(_segs[lastIdx] instanceof StringSegment)) return false;
             return ((StringSegment)_segs[lastIdx]).trailsBlank();
         }
-        public void trimLastBlank () {
+        default void trimLastBlank () {
+            Template.Segment[] _segs = _segs();
             int idx = _segs.length-1;
             _segs[idx] = ((StringSegment)_segs[idx]).trimTrailBlank();
         }
+        boolean isStandaloneEnd();
+        boolean isStandaloneStart();
+        Template.Segment[] _segs();
+    }
+    
+    protected interface BlockReplaceable {
+        public Segment replaceBlocks(Map<String, BlockSegment> blocks);
+    }
+    
+    /** A helper class for section-like segments. */
+    protected static abstract class AbstractSectionSegment extends NamedSegment implements StandaloneSection, BlockReplaceable {
 
-        protected BlockSegment (String name, Template.Segment[] segs, int line) {
+        protected AbstractSectionSegment (Compiler compiler, String name, Template.Segment[] segs, int line) {
             super(name, line);
+            _comp = compiler;
             _segs = trim(segs, false);
         }
-        protected BlockSegment (BlockSegment original, Template.Segment[] segs) {
+        protected AbstractSectionSegment (AbstractSectionSegment original, Template.Segment[] segs) {
             super(original._name, original._line);
+            _comp = original._comp;
             // this call assumes the segments are already trimmed
             _segs = segs;
         }
@@ -1185,30 +1327,27 @@ public class Mustache {
             }
         }
 
-        protected abstract BlockSegment indent (String indent, boolean first, boolean last);
+        protected abstract AbstractSectionSegment indent (String indent, boolean first, boolean last);
 
-        @Override
-        boolean isStandalone() {
-            return _standaloneEnd;
-        }
-        boolean isStandaloneStart() {
-            return _standaloneStart;
-        }
+        @Override public boolean isStandalone() { return _standaloneEnd; }
+        @Override public boolean isStandaloneStart() { return _standaloneStart; }
+        @Override public boolean isStandaloneEnd() { return _standaloneEnd; }
+
+        @Override public Segment[] _segs() { return _segs; }
         
+        protected final Compiler _comp;
         protected final Template.Segment[] _segs;
         protected boolean _standaloneStart = false;
         protected boolean _standaloneEnd = false;
     }
 
     /** A segment that represents a section. */
-    protected static class SectionSegment extends BlockSegment {
+    protected static class SectionSegment extends AbstractSectionSegment {
         public SectionSegment (Compiler compiler, String name, Template.Segment[] segs, int line) {
-            super(name, segs, line);
-            _comp = compiler;
+            super(compiler, name, segs, line);
         }
         protected SectionSegment(SectionSegment original, Template.Segment[] segs) {
             super(original, segs);
-            _comp = original._comp;
         }
         @Override public void execute (Template tmpl, Template.Context ctx, Writer out) {
             Object value = tmpl.getSectionValue(ctx, _name, _line); // won't return null
@@ -1249,12 +1388,14 @@ public class Mustache {
             }
         }
         @Override protected SectionSegment indent (String indent, boolean first, boolean last) {
-            // If the end tag is standalone we do NOT add the indent on the end
-            // (e.g. the newline following the end tag).
-            // This is because the block always owns the newlines within the block but
-            // it only owns the last newline following the end tag if and only if 
-            // the closing tag is standalone.
             Template.Segment[] segs = indentSegs(_segs, indent, first, last);
+            if (segs == _segs) {
+                return this;
+            }
+            return new SectionSegment(this, segs);
+        }
+        @Override public SectionSegment replaceBlocks(Map<String, BlockSegment> blocks) {
+            Template.Segment[] segs = replaceBlockSegs(_segs, blocks);
             if (segs == _segs) {
                 return this;
             }
@@ -1263,13 +1404,55 @@ public class Mustache {
         @Override public String toString () {
             return "Section(" + _name + ":" + _line + "): " + Arrays.toString(_segs);
         }
-        protected final Compiler _comp;
+    }
+    
+    /** A parent partial parameter using $ as the sigil. */
+    protected static class BlockSegment extends AbstractSectionSegment {
+        public BlockSegment(Compiler compiler, String name, Segment[] segs, int line) {
+            super(compiler, name, segs, line);
+        }
+        protected BlockSegment(BlockSegment original, Template.Segment[] segs) {
+            super(original, segs);
+        }
+        @Override public void execute (Template tmpl, Template.Context ctx, Writer out) {
+            executeSegs(tmpl, ctx, out);
+        }
+        @Override public void decompile (Delims delims, StringBuilder into) {
+            delims.addTag('$', _name, into);
+            for (Template.Segment seg : _segs) seg.decompile(delims, into);
+            delims.addTag('/', _name, into);
+        }
+        @Override public void visit (Visitor visitor) {
+            if (visitor.visitSection(_name)) {
+                for (Template.Segment seg : _segs) {
+                    seg.visit(visitor);
+                }
+            }
+        }
+        @Override protected BlockSegment indent (String indent, boolean first, boolean last) {
+            // Current indenting block segments is not defined by spec but might eventually
+            Template.Segment[] segs = indentSegs(_segs, indent, first, last);
+            if (segs == _segs) {
+                return this;
+            }
+            return new BlockSegment(this, segs);
+        }
+        @Override public BlockSegment replaceBlocks(Map<String, BlockSegment> blocks) {
+            BlockSegment bs = blocks.get(_name);
+            if (bs == null) {
+                return this;
+            }
+            return new BlockSegment(this, bs._segs);
+        }
+        @Override public String toString () {
+            return "Block(" + _name + ":" + _line + "): " + Arrays.toString(_segs);
+        }
     }
 
     /** A segment that represents an inverted section. */
-    protected static class InvertedSegment extends BlockSegment {
+    protected static class InvertedSegment extends AbstractSectionSegment {
         public InvertedSegment (Compiler compiler, String name, Template.Segment[] segs, int line) {
-            super(name, segs, line);
+            super(compiler, name, segs, line);
             _comp = compiler;
         }
         protected InvertedSegment (InvertedSegment original, Template.Segment[] segs) {
@@ -1312,6 +1495,13 @@ public class Mustache {
         @Override
         protected InvertedSegment indent (String indent, boolean first, boolean last) {
             Template.Segment[] segs = indentSegs(_segs, indent, first, last);
+            if (segs == _segs) {
+                return this;
+            }
+            return new InvertedSegment(this, segs);
+        }
+        @Override public InvertedSegment replaceBlocks(Map<String, BlockSegment> blocks) {
+            Template.Segment[] segs = replaceBlockSegs(_segs, blocks);
             if (segs == _segs) {
                 return this;
             }

--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -176,7 +176,7 @@ public class Template {
         if (indent.equals("")) {
             return this;
         }
-        Segment[] copySegs = Mustache.indentSegs(_segs, indent);
+        Segment[] copySegs = Mustache.indentSegs(_segs, indent, false,false);
         if (copySegs == _segs) {
             return this;
         }

--- a/src/main/java/com/samskivert/mustache/Template.java
+++ b/src/main/java/com/samskivert/mustache/Template.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
+import com.samskivert.mustache.Mustache.BlockSegment;
+
 /**
  * Represents a compiled template. Templates are executed with a <em>context</em> to generate
  * output. The context can be any tree of objects. Variables are resolved against the context.
@@ -164,7 +166,7 @@ public class Template {
         _compiler = compiler;
         _fcache = compiler.collector.createFetcherCache();
     }
-    
+
     protected Template indent(String indent) {
         /*
          * What we want to do here is rebuild this partial template
@@ -177,6 +179,17 @@ public class Template {
             return this;
         }
         Segment[] copySegs = Mustache.indentSegs(_segs, indent, false,false);
+        if (copySegs == _segs) {
+            return this;
+        }
+        return new Template(copySegs, _compiler);
+    }
+
+    protected Template replaceBlocks(Map<String, BlockSegment> blocks) {
+        if (blocks.isEmpty()) {
+            return this;
+        }
+        Segment[] copySegs = Mustache.replaceBlockSegs(_segs, blocks);
         if (copySegs == _segs) {
             return this;
         }

--- a/src/test/java/com/samskivert/mustache/PartialThreadSafeTest.java
+++ b/src/test/java/com/samskivert/mustache/PartialThreadSafeTest.java
@@ -22,7 +22,6 @@ public class PartialThreadSafeTest {
     
     @Test
     public void testPartialThreadSafe() throws Exception {
-        long t = System.currentTimeMillis();
         AtomicInteger loadCount = new AtomicInteger();
         TemplateLoader loader = new TemplateLoader() {
 
@@ -61,9 +60,6 @@ public class PartialThreadSafeTest {
         }
         assertTrue(q.isEmpty());
         assertEquals(1, loadCount.get());
-        System.out.println(loadCount);
-        System.out.println(System.currentTimeMillis() - t);
-
     }
 
 }

--- a/src/test/java/com/samskivert/mustache/PartialThreadSafeTest.java
+++ b/src/test/java/com/samskivert/mustache/PartialThreadSafeTest.java
@@ -1,0 +1,69 @@
+package com.samskivert.mustache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import com.samskivert.mustache.Mustache.TemplateLoader;
+
+public class PartialThreadSafeTest {
+    
+    @Test
+    public void testPartialThreadSafe() throws Exception {
+        long t = System.currentTimeMillis();
+        AtomicInteger loadCount = new AtomicInteger();
+        TemplateLoader loader = new TemplateLoader() {
+
+            @Override
+            public Reader getTemplate(String name) throws Exception {
+                if ("partial".equals(name)) {
+                    loadCount.incrementAndGet();
+                    TimeUnit.MILLISECONDS.sleep(20);
+                    return new StringReader("Hello");
+                }
+                throw new IOException(name);
+            }
+        };
+
+        Template template = Mustache.compiler().withLoader(loader).compile("{{stuff}}\n\t{{> partial }}");
+        ExecutorService executor = Executors.newFixedThreadPool(64);
+        ConcurrentLinkedDeque<Exception> q = new ConcurrentLinkedDeque<>();
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("stuff", "Foo");
+        for (int i = 100; i > 0; i--) {
+            int ii = i;
+            executor.execute(() -> {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(ii % 10);
+                    template.execute(m);
+                } catch (Exception e) {
+                    q.add(e);
+                }
+            });
+        }
+        executor.shutdown();
+        executor.awaitTermination(10_000, TimeUnit.MILLISECONDS);
+        if (!q.isEmpty()) {
+            System.out.println(q);
+        }
+        assertTrue(q.isEmpty());
+        assertEquals(1, loadCount.get());
+        System.out.println(loadCount);
+        System.out.println(System.currentTimeMillis() - t);
+
+    }
+
+}

--- a/src/test/java/com/samskivert/mustache/specs/CustomSpecTest.java
+++ b/src/test/java/com/samskivert/mustache/specs/CustomSpecTest.java
@@ -16,7 +16,9 @@ public class CustomSpecTest extends SpecTest {
     @Parameters(name = "{1}")
     public static Collection<Object[]> data () {
         String[] groups = new String[] {
-            "partials"
+            "sections",
+            "partials",
+            "~inheritance"
         };
         return SpecTest.data("/custom/specs/", groups);
     }

--- a/src/test/java/com/samskivert/mustache/specs/OfficialSpecTest.java
+++ b/src/test/java/com/samskivert/mustache/specs/OfficialSpecTest.java
@@ -21,7 +21,8 @@ public class OfficialSpecTest extends SpecTest {
             "interpolation",
             "inverted",
             "sections",
-            "partials"
+            "partials",
+            "~inheritance"
         };
         return SpecTest.data("/specs/specs/", groups);
     }

--- a/src/test/java/com/samskivert/mustache/specs/Spec.java
+++ b/src/test/java/com/samskivert/mustache/specs/Spec.java
@@ -5,6 +5,7 @@
 package com.samskivert.mustache.specs;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Consumer;
 
 /**
@@ -57,6 +58,15 @@ public class Spec
         value.accept(getDescription());
         label.accept("template");
         value.accept(getTemplate());
+        if (! partials.isEmpty()) {
+            label.accept("partials");
+            sb.append("\n");
+            for( Entry<String, String> e : partials.entrySet()) {
+                sb.append("\t").append(e.getKey()).append(":\n");
+                value.accept(e.getValue());
+            }
+            sb.append("\n");
+        }
         label.accept("expected");
         value.accept(getExpectedOutput());
         return sb.toString();

--- a/src/test/java/com/samskivert/mustache/specs/Spec.java
+++ b/src/test/java/com/samskivert/mustache/specs/Spec.java
@@ -4,6 +4,7 @@
 
 package com.samskivert.mustache.specs;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
@@ -20,6 +21,7 @@ public class Spec
         this.map = map;
         @SuppressWarnings("unchecked") Map<String, String> partials =
             (Map<String, String>) map.get("partials");
+        if (partials == null) partials = Collections.emptyMap();
         this.partials = partials;
     }
 

--- a/src/test/java/com/samskivert/mustache/specs/SpecTest.java
+++ b/src/test/java/com/samskivert/mustache/specs/SpecTest.java
@@ -31,7 +31,7 @@ public abstract class SpecTest {
     public void test () throws Exception {
         //System.out.println("Testing: " + name);
         SpecAwareTemplateLoader loader = new SpecAwareTemplateLoader(spec);
-        Mustache.Compiler compiler = Mustache.compiler().defaultValue("").withLoader(loader);
+        Mustache.Compiler compiler = Mustache.compiler().emptyStringIsFalse(true).defaultValue("").withLoader(loader);
         String tmpl = spec.getTemplate();
         String desc = String.format("Template: '''%s'''\nData: '%s'\n",
                                     uncrlf(tmpl), uncrlf(spec.getData().toString()));

--- a/src/test/java/com/samskivert/mustache/specs/SpecTest.java
+++ b/src/test/java/com/samskivert/mustache/specs/SpecTest.java
@@ -56,6 +56,7 @@ public abstract class SpecTest {
             // specifications, but we throw an exception (and rightfully so IMO; this is not a
             // place where silent failure is helpful), so just ignore those test failures
             if (!e.getMessage().contains("Invalid delimiter")) {
+                e.printStackTrace();
                 Assert.fail(
                 desc + "\nExpected: " + uncrlf(spec.getExpectedOutput()) + "\nError: " + e);
             }

--- a/src/test/resources/custom/specs/partials.yml
+++ b/src/test/resources/custom/specs/partials.yml
@@ -24,8 +24,8 @@ tests:
       nest: "2\n{{{content}}}\n2\n"
     expected: "|\n 1\n  2\n  <\n->\n  2\n 1\n|\n"
 
-  - name: Standalone Indentation
-    desc: Each line of the partial should be indented before rendering.
+  - name: Partial Section Indentation End Content
+    desc: Closing end sections that have content on same line should be indented
     data: { content: "<\n->" }
     template: |
       \
@@ -34,12 +34,83 @@ tests:
     partials:
       partial: |
         |
-        {{{content}}}
+        {{#content}}
+        {{{.}}}
+        {{/content}}-
         |
     expected: |
       \
        |
        <
       ->
+       -
        |
       /
+
+  - name: Partial Section Indentation Inside Start Content
+    desc: Content that is not white space on same line as section start tag inside should be indented
+    data: { content: "<\n->" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        {{#content}}-
+        {{{.}}}
+        {{/content}}
+        |
+    expected: |
+      \
+       |
+       -
+       <
+      ->
+       |
+      /
+
+  - name: Partial Section Indentation Start Content
+    desc: Content that is not white space on same line as section start tags should be indented
+    data: { content: "<\n->" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        -{{#content}}
+        {{{.}}}
+        {{/content}}
+        |
+    expected: |
+      \
+       |
+       -
+       <
+      ->
+       |
+      /
+
+  - name: Partial Indentation With Empty Sections
+    desc: Empty standlone sections should not have indentation before or after
+    data: { content: "" }
+    template: |
+      \
+       {{>partial}}
+      /
+    partials:
+      partial: |
+        |
+        {{#content}}
+        {{{.}}}
+        {{/content}}
+        |
+    expected: |
+      \
+       |
+       |
+      /
+
+# The extra newline on the end is required

--- a/src/test/resources/custom/specs/sections.yml
+++ b/src/test/resources/custom/specs/sections.yml
@@ -1,0 +1,17 @@
+overview: |
+  Section and End Section tags SHOULD be treated as standalone when
+  appropriate.
+tests:
+  - name: Standalone Lines
+    desc: Standalone lines should be removed from the template.
+    data: { boolean: true }
+    template: |
+      | This Is
+      {{#boolean}}{{^missing}}|{{/missing}}{{/boolean}}
+      | A Line
+    expected: |
+      | This Is
+      |
+      | A Line
+
+# eof

--- a/src/test/resources/custom/specs/~inheritance.yml
+++ b/src/test/resources/custom/specs/~inheritance.yml
@@ -1,0 +1,12 @@
+overview: |
+  Custom inheritance tests.
+tests:
+  - name: Non block content should not impact standalone blocks 
+    desc: Content inside a parent call that is not block tags should be ignored 
+    data: { }
+    template: "{{<parent}}ignore{{$ballmer}}\npeaked\n\n:(\n{{/ballmer}}{{/parent}}"
+    partials:
+      parent: "{{$ballmer}}peaking{{/ballmer}}"
+    expected: "peaked\n\n:(\n"
+
+# eof


### PR DESCRIPTION
THIS is a draft PR. Do not merge as it requires #154 and #155 . 

Ignoring whitespace issues it works.

The whitespace issue has to do with standalone for parents allowing something like:

```
{{<parent}}...{{/parent}}
```

Basically whatever is in the parent that is on the same line as the opening and closing is considered standalone for both tags.

I should have it fixed soon.