### PR TITLE
Make the build reproducible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
   <properties>
     <source.level>1.9</source.level>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <!-- This will be replaced by the release plugin -->
+    <project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
@samskivert 

This PR will make the build reproducible (e.g. checksum will match).

https://maven.apache.org/guides/mini/guide-reproducible-builds.html

After we release with this change I will go register with:

https://github.com/jvm-repo-rebuild/reproducible-central

Reproducible builds are important for security and given how many use and given how simple of a change I think it is worth it.